### PR TITLE
(GH-3) Added parsing of psake tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
 		"Snippets"
 	],
 	"activationEvents": [
-		"onCommand:psake.buildFile"
+		"onCommand:psake.buildFile",
+		"onCommand:workbench.action.tasks.runTask"
 	],
 	"main": "./out/psakeMain",
 	"contributes": {
@@ -44,7 +45,23 @@
 				"command": "psake.buildFile",
 				"title": "psake: Install sample build file"
 			}
-		]
+		],
+		"configuration": {
+			"type": "object",
+			"title": "psake configuration",
+			"properties": {
+				"psake.taskRunner":{
+					"type": "object",
+					"default":{
+						"autoDetect": true,
+						"scriptsIncludePattern": "psakefile.ps1",
+						"scriptsExcludePattern": "",
+						"taskRegularExpression": "Task (.*?) "
+					},
+					"description": "The psake Task Runner Settings"
+				}
+			}
+		}
 	},
 	"scripts": {
 		"vscode:prepublish": "tsc -p ./",

--- a/src/psakeMain.ts
+++ b/src/psakeMain.ts
@@ -1,9 +1,100 @@
 import * as vscode from 'vscode';
 import { installBuildFileCommand } from './buildFile/psakeBuildFileCommand';
+import * as fs from 'fs';
+import * as os from 'os';
+
+let taskProvider: vscode.Disposable | undefined;
 
 export function activate(context: vscode.ExtensionContext): void {
     // Register the build file command.
     context.subscriptions.push(vscode.commands.registerCommand('psake.buildFile', async () => {
         installBuildFileCommand();
     }));
+
+    function onConfigurationChanged() {
+        let autoDetect = vscode.workspace.getConfiguration('psake').get('taskRunner.autoDetect');
+        if (taskProvider && !autoDetect) {
+            taskProvider.dispose();
+            taskProvider = undefined;
+        } else if (!taskProvider && autoDetect) {
+            taskProvider = vscode.workspace.registerTaskProvider('psake', {
+                provideTasks: async () => {
+                    return await getpsakeScriptsAsTasks();
+                },
+                resolveTask(_task: vscode.Task): vscode.Task | undefined {
+                    return undefined;
+                }
+            });
+        }
+    }
+
+    vscode.workspace.onDidChangeConfiguration(onConfigurationChanged);
+    onConfigurationChanged();
 }
+
+export function deactivate() {
+    if (taskProvider) {
+        taskProvider.dispose();
+    }
+}
+
+interface psakeTaskDefinition extends vscode.TaskDefinition {
+    script: string;
+    file?: string;
+}
+
+async function getpsakeScriptsAsTasks(): Promise<vscode.Task[]> {
+    let workspaceRoot = vscode.workspace.rootPath;
+    let emptyTasks: vscode.Task[] = [];
+
+    if (!workspaceRoot) {
+        return emptyTasks;
+    }
+
+    try {
+        let psakeConfig = vscode.workspace.getConfiguration('psake');
+        let files = await vscode.workspace.findFiles(psakeConfig.taskRunner.scriptsIncludePattern, psakeConfig.taskRunner.scriptsExcludePattern);
+
+        if (files.length === 0) {
+            return emptyTasks;
+        }
+
+        const result: vscode.Task[] = [];
+
+        files.forEach(file => {
+            const contents = fs.readFileSync(file.fsPath).toString();
+
+            let taskRegularExpression = new RegExp(psakeConfig.taskRunner.taskRegularExpression, "g");
+
+            let matches, taskNames = [];
+
+            while (matches = taskRegularExpression.exec(contents)) {
+                taskNames.push(matches[1]);
+            }
+
+            taskNames.forEach(taskName => {
+                const kind: psakeTaskDefinition = {
+                    type: 'psake',
+                    script: taskName
+                };
+
+                // TODO: Need to put something here
+                let buildCommand = ``;
+
+                if (os.platform() === "win32") {
+                    // TODO: Need to put something here
+                    buildCommand = ``;
+                }
+
+                const buildTask = new vscode.Task(kind, `Run ${taskName}`, 'psake', new vscode.ShellExecution(`${buildCommand}`), []);
+                buildTask.group = vscode.TaskGroup.Build;
+
+                result.push(buildTask);
+            });
+        });
+
+        return result;
+    } catch (e) {
+        return [];
+    }
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added the ability to parse the psakefile.ps1 file, looking for Task definitions.  These are then provided for selection, and can be executed via the Integrated Terminal window.

## Related Issue
#3 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Allows the end user to easily "see" the build Tasks that they have available for their current project.

## How Has This Been Tested?
Developer tests on my machine, needs much more testing, and comments.

## Screenshots (if appropriate):
See related issue

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
