### PR TITLE
fix: 🐛 Improve case-insensitive file detection and activation events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.0.2] 2026-03-13
+
+### Fixed
+
+- **Case-insensitive file detection**: extension now finds `psakefile.ps1` and `build.ps1` regardless of casing (e.g., `psakeFile.ps1`, `Build.ps1`, `BUILD.ps1`)
+- Updated activation events to include common case variations of psake and build files
+
 ## [1.0.1] 2026-03-09
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "psake",
 	"publisher": "psake",
 	"description": "Psake build script language support for Visual Studio Code.",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"icon": "images/psake.png",
 	"private": true,
 	"author": {
@@ -31,10 +31,15 @@
 		"Other"
 	],
 	"activationEvents": [
-		"workspaceContains:**/psakefile.ps1",
-		"workspaceContains:**/psake.ps1",
+		"onTaskType:psake",
 		"workspaceContains:**/build.ps1",
-		"onTaskType:psake"
+		"workspaceContains:**/Build.ps1",
+		"workspaceContains:**/BUILD.ps1",
+		"workspaceContains:**/psake.ps1",
+		"workspaceContains:**/psakefile.ps1",
+		"workspaceContains:**/psakeFile.ps1",
+		"workspaceContains:**/PsakeFile.ps1",
+		"workspaceContains:**/PSAKEFILE.ps1"
 	],
 	"main": "./dist/extension.js",
 	"contributes": {

--- a/src/psakeParser.ts
+++ b/src/psakeParser.ts
@@ -44,12 +44,27 @@ export function parsePsakeFile(content: string): PsakeTaskInfo[] {
 }
 
 /**
+ * Converts a filename to a case-insensitive glob pattern.
+ * Example: "psakefile.ps1" -> "[pP][sS][aA][kK][eE][fF][iI][lL][eE].ps1"
+ */
+function toCaseInsensitivePattern(filename: string): string {
+    return filename.split('').map(char => {
+        if (/[a-zA-Z]/.test(char)) {
+            return `[${char.toLowerCase()}${char.toUpperCase()}]`;
+        }
+        return char;
+    }).join('');
+}
+
+/**
  * Discovers all psakefile.ps1 files in the current workspace.
+ * Uses case-insensitive matching to find files regardless of casing.
  */
 export async function findPsakeFiles(): Promise<vscode.Uri[]> {
     const config = vscode.workspace.getConfiguration('psake');
     const buildFileName: string = config.get('buildFile') ?? 'psakefile.ps1';
-    const pattern = `**/${buildFileName}`;
+    const caseInsensitiveFileName = toCaseInsensitivePattern(buildFileName);
+    const pattern = `**/${caseInsensitiveFileName}`;
     return vscode.workspace.findFiles(pattern, '**/node_modules/**');
 }
 

--- a/src/taskProvider.ts
+++ b/src/taskProvider.ts
@@ -164,11 +164,14 @@ export class PsakeTaskProvider implements vscode.TaskProvider {
         } else if (configured) {
             result = configured;
         } else {
-            // Auto-detect build.ps1 in workspace root
-            const buildPs1 = vscode.Uri.joinPath(folder.uri, 'build.ps1');
+            // Auto-detect build.ps1 in workspace root (case-insensitive)
             try {
-                await vscode.workspace.fs.stat(buildPs1);
-                result = 'build.ps1';
+                const files = await vscode.workspace.fs.readDirectory(folder.uri);
+                const buildFile = files.find(([name, type]) => 
+                    type === vscode.FileType.File && 
+                    name.toLowerCase() === 'build.ps1'
+                );
+                result = buildFile ? buildFile[0] : undefined;
             } catch {
                 result = undefined;
             }


### PR DESCRIPTION
* Updated `version` to 1.0.2.
* Enhanced file detection for `build.ps1` and `psakefile.ps1` to be case-insensitive.
* Modified activation events to include various case variations of psake and build files.
* Introduced a utility function to convert filenames to case-insensitive glob patterns.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
