### PR TITLE
1.1.0 - Add Support for Includes & FromModule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## [1.1.0] 2026-03-14
+
+### Added
+
+- **Module task resolution (`-FromModule`)**: tasks can now reference other
+  psake modules with version constraints (MinimumVersion, MaximumVersion,
+  RequiredVersion, LessThanVersion). Module tasks are resolved to show
+  dependencies and descriptions in the tree view and jump-to-definition
+  navigates to the module's psakeFile.ps1
+- **Include file support**: tasks from files included via `Include` statements
+  (with `-Path`, `-LiteralPath`, or `-fileNamePathToInclude` parameters) are
+  now discovered and displayed in the tree view, task provider, and code lens
+- **Full task expansion**: all tasks exported by referenced modules become
+  available to the build, appearing in task lists and completions
+- **Source file tracking**: tasks from modules or include files retain their
+  source file path for accurate navigation and visual distinction
+- **New snippet**: `psakeTaskFromModule` for quickly authoring module reference
+  tasks with version constraints
+
+### Changed
+
+- Parser now extracts `-FromModule` parameter and version constraints
+- Tree view, task provider, and completions now show module and include task
+  origins via icons and metadata
+- Task definition interface now tracks module/include source and resolved state
+
+### Fixed
+
+- Version constraint comparison logic matches psake's Test-ModuleVersion
+  semantics exactly (minimum ≥, maximum ≤, less-than <, required ==)
+
 ## [1.0.2] 2026-03-13
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "psake",
 	"publisher": "psake",
 	"description": "Psake build script language support for Visual Studio Code.",
-	"version": "1.0.2",
+	"version": "1.1.0",
 	"icon": "images/psake.png",
 	"private": true,
 	"author": {

--- a/snippets/powershell.json
+++ b/snippets/powershell.json
@@ -139,5 +139,12 @@
 			"Assert (${1:condition}) '${2:Assertion failed: description}'"
 		],
 		"description": "Assert a condition is true, failing the build with a message if it is not."
+	},
+	"psake Task (from module)": {
+		"prefix": "psakeTaskFromModule",
+		"body": [
+			"Task ${1:TaskName} -FromModule ${2:ModuleName} -MinimumVersion '${3:0.1.0}'"
+		],
+		"description": "A psake task imported from an external psake module. The task implementation (action and dependencies) is resolved from the named module's psakeFile.ps1 at build time."
 	}
 }

--- a/src/codeLensProvider.ts
+++ b/src/codeLensProvider.ts
@@ -1,12 +1,15 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { parsePsakeFile } from './psakeParser.js';
+import { PsakeModuleResolver, enrichModuleTasks } from './moduleResolver.js';
 
 export class PsakeCodeLensProvider implements vscode.CodeLensProvider {
     private readonly _onDidChangeCodeLenses = new vscode.EventEmitter<void>();
     readonly onDidChangeCodeLenses = this._onDidChangeCodeLenses.event;
+    private readonly resolver: PsakeModuleResolver | undefined;
 
-    constructor(watcher: vscode.FileSystemWatcher) {
+    constructor(watcher: vscode.FileSystemWatcher, resolver?: PsakeModuleResolver) {
+        this.resolver = resolver;
         watcher.onDidChange(() => this._onDidChangeCodeLenses.fire());
         watcher.onDidCreate(() => this._onDidChangeCodeLenses.fire());
         watcher.onDidDelete(() => this._onDidChangeCodeLenses.fire());
@@ -31,11 +34,15 @@ export class PsakeCodeLensProvider implements vscode.CodeLensProvider {
         }
 
         const tasks = parsePsakeFile(document.getText());
+        if (this.resolver) {
+            await enrichModuleTasks(tasks, this.resolver);
+        }
         const relativeFile = path.relative(folder.uri.fsPath, document.uri.fsPath);
 
-        return tasks.map(task => {
+        const lenses: vscode.CodeLens[] = [];
+        for (const task of tasks) {
             const range = new vscode.Range(task.line, 0, task.line, 0);
-            return new vscode.CodeLens(range, {
+            lenses.push(new vscode.CodeLens(range, {
                 title: '$(play) Run Task',
                 command: 'psake.runTask',
                 arguments: [{
@@ -43,8 +50,15 @@ export class PsakeCodeLensProvider implements vscode.CodeLensProvider {
                     buildFile: relativeFile,
                     workspaceFolder: folder,
                 }],
-            });
-        });
+            }));
+            if (task.fromModule && task.moduleResolved === false) {
+                lenses.push(new vscode.CodeLens(range, {
+                    title: `$(warning) Module not found: ${task.fromModule}`,
+                    command: '',
+                }));
+            }
+        }
+        return lenses;
     }
 
     private isPsakeFile(document: vscode.TextDocument): boolean {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@ import { PsakeTaskProvider } from './taskProvider.js';
 import { PsakeTreeDataProvider } from './treeView.js';
 import { PsakeTaskCompletionProvider } from './tasksJsonCompletionProvider.js';
 import { PsakeCodeLensProvider } from './codeLensProvider.js';
+import { PsakeModuleResolver } from './moduleResolver.js';
 import { installBuildFileCommand } from './scaffoldCommand.js';
 import { syncTasksCommand } from './syncTasksCommand.js';
 import { findPsakeFiles } from './psakeParser.js';
@@ -28,14 +29,17 @@ export function activate(context: vscode.ExtensionContext): void {
     let watcher = vscode.workspace.createFileSystemWatcher(getBuildFilePattern());
     context.subscriptions.push(watcher);
 
+    // Module resolver — shared across tree view, task provider, and completions
+    const resolver = new PsakeModuleResolver();
+
     // Tree View
-    const treeProvider = new PsakeTreeDataProvider(watcher);
+    const treeProvider = new PsakeTreeDataProvider(watcher, resolver);
     context.subscriptions.push(
         vscode.window.registerTreeDataProvider('psakeTasksView', treeProvider)
     );
 
     // Task Provider
-    const taskProvider = new PsakeTaskProvider(watcher);
+    const taskProvider = new PsakeTaskProvider(watcher, resolver);
     context.subscriptions.push(
         vscode.tasks.registerTaskProvider('psake', taskProvider)
     );
@@ -45,13 +49,13 @@ export function activate(context: vscode.ExtensionContext): void {
         language: 'jsonc',
         pattern: '**/.vscode/tasks.json',
     };
-    const completionProvider = new PsakeTaskCompletionProvider(watcher);
+    const completionProvider = new PsakeTaskCompletionProvider(watcher, resolver);
     context.subscriptions.push(
         vscode.languages.registerCompletionItemProvider(tasksJsonSelector, completionProvider, '"')
     );
 
     // CodeLens: "▶ Run Task" above each Task declaration in psakefile
-    const codeLensProvider = new PsakeCodeLensProvider(watcher);
+    const codeLensProvider = new PsakeCodeLensProvider(watcher, resolver);
     context.subscriptions.push(
         vscode.languages.registerCodeLensProvider(
             { language: 'powershell', pattern: getBuildFilePattern() },
@@ -96,6 +100,7 @@ export function activate(context: vscode.ExtensionContext): void {
     // Tree view commands
     context.subscriptions.push(
         vscode.commands.registerCommand('psake.refreshTasks', () => {
+            resolver.clearCache();
             treeProvider.refresh();
         }),
 

--- a/src/moduleResolver.ts
+++ b/src/moduleResolver.ts
@@ -1,0 +1,221 @@
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { parsePsakeFile, PsakeTaskInfo } from './psakeParser.js';
+import { detectPowerShellExecutable, runPowerShellScript } from './powershellUtils.js';
+import { logError } from './log.js';
+
+// ---------------------------------------------------------------------------
+// Version constraint types and helpers
+// ---------------------------------------------------------------------------
+
+export interface VersionConstraints {
+  requiredVersion?: string;
+  minimumVersion?: string;
+  maximumVersion?: string;
+  lessThanVersion?: string;
+}
+
+/** Splits a version string into a numeric segment array for comparison. */
+function parseVersion(version: string): number[] {
+  return version.split('.').map(n => parseInt(n, 10) || 0);
+}
+
+/** Returns negative / zero / positive like a standard comparator. */
+function compareVersions(a: string, b: string): number {
+  const av = parseVersion(a);
+  const bv = parseVersion(b);
+  const len = Math.max(av.length, bv.length);
+  for (let i = 0; i < len; i++) {
+    const diff = (av[i] ?? 0) - (bv[i] ?? 0);
+    if (diff !== 0) {
+      return diff;
+    }
+  }
+  return 0;
+}
+
+/**
+ * Replicates psake's Test-ModuleVersion semantics:
+ *   requiredVersion  → exact match (sets both min and max internally in psake)
+ *   minimumVersion   → version >= minimumVersion  (inclusive)
+ *   maximumVersion   → version <= maximumVersion  (inclusive)
+ *   lessThanVersion  → version <  lessThanVersion (exclusive)
+ *
+ * When no constraints are supplied, any version matches.
+ */
+export function matchesVersionConstraints(version: string, constraints: VersionConstraints): boolean {
+  const { requiredVersion, minimumVersion, maximumVersion, lessThanVersion } = constraints;
+
+  if (!requiredVersion && !minimumVersion && !maximumVersion && !lessThanVersion) {
+    return true;
+  }
+
+  if (requiredVersion) {
+    return compareVersions(version, requiredVersion) === 0;
+  }
+  if (minimumVersion && compareVersions(version, minimumVersion) < 0) {
+    return false;
+  }
+  if (maximumVersion && compareVersions(version, maximumVersion) > 0) {
+    return false;
+  }
+  if (lessThanVersion && compareVersions(version, lessThanVersion) >= 0) {
+    return false;
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Module resolution
+// ---------------------------------------------------------------------------
+
+interface ModuleInfo {
+  ModuleBase: string;
+  Version: string;
+}
+
+function cacheKey(moduleName: string, constraints: VersionConstraints): string {
+  return [
+    moduleName,
+    constraints.requiredVersion ?? '',
+    constraints.minimumVersion ?? '',
+    constraints.maximumVersion ?? '',
+    constraints.lessThanVersion ?? '',
+  ].join('|');
+}
+
+export class PsakeModuleResolver {
+  private readonly cache = new Map<string, PsakeTaskInfo[]>();
+
+  /** Clears all cached resolutions (call on explicit user refresh). */
+  clearCache(): void {
+    this.cache.clear();
+  }
+
+  /**
+   * Resolves all tasks from the named psake module that satisfy the given
+   * version constraints.  Results are cached by (moduleName, constraints).
+   *
+   * Returns an empty array when the module cannot be found, when no version
+   * satisfies the constraints, or when the module has no psakeFile.ps1.
+   */
+  async resolveModuleTasks(moduleName: string, constraints: VersionConstraints): Promise<PsakeTaskInfo[]> {
+    const key = cacheKey(moduleName, constraints);
+    if (this.cache.has(key)) {
+      return this.cache.get(key)!;
+    }
+    const result = await this.doResolve(moduleName, constraints);
+    this.cache.set(key, result);
+    return result;
+  }
+
+  private async doResolve(moduleName: string, constraints: VersionConstraints): Promise<PsakeTaskInfo[]> {
+    let moduleBase: string | undefined;
+    try {
+      moduleBase = await this.findModuleBase(moduleName, constraints);
+    } catch (err) {
+      logError(err, false);
+      return [];
+    }
+
+    if (!moduleBase) {
+      return [];
+    }
+
+    const psakeFilePath = path.join(moduleBase, 'psakeFile.ps1');
+    try {
+      const uri = vscode.Uri.file(psakeFilePath);
+      const bytes = await vscode.workspace.fs.readFile(uri);
+      const content = Buffer.from(bytes).toString('utf8');
+      return parsePsakeFile(content);
+    } catch {
+      // Module exists but has no psakeFile.ps1 — not a psake task module.
+      return [];
+    }
+  }
+
+  private async findModuleBase(moduleName: string, constraints: VersionConstraints): Promise<string | undefined> {
+    const exe = await detectPowerShellExecutable();
+
+    // Escape single-quotes in the module name to prevent injection.
+    const safeName = moduleName.replace(/'/g, "''");
+    const script = [
+      `Get-Module -Name '${safeName}' -ListAvailable -ErrorAction SilentlyContinue`,
+      `| Select-Object -Property ModuleBase, @{N='Version';E={$_.Version.ToString()}}`,
+      `| ConvertTo-Json -Compress`,
+    ].join(' ');
+
+    let output: string;
+    try {
+      output = await runPowerShellScript(exe, script);
+    } catch (err) {
+      logError(err, false);
+      return undefined;
+    }
+
+    if (!output || output === 'null') {
+      return undefined;
+    }
+
+    let modules: ModuleInfo[];
+    try {
+      const parsed: unknown = JSON.parse(output);
+      // ConvertTo-Json returns an object (not array) when there is only one result.
+      modules = Array.isArray(parsed) ? (parsed as ModuleInfo[]) : [parsed as ModuleInfo];
+    } catch {
+      return undefined;
+    }
+
+    // Filter by version constraints; pick the highest matching version.
+    const matching = modules
+      .filter(m => matchesVersionConstraints(m.Version, constraints))
+      .sort((a, b) => compareVersions(b.Version, a.Version));
+
+    return matching[0]?.ModuleBase;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shared enrichment helper used by tree view, task provider, and completions
+// ---------------------------------------------------------------------------
+
+/**
+ * Mutates each task in `tasks` that has a `-FromModule` parameter by:
+ *  - setting `moduleResolved` to true/false
+ *  - merging the module task's dependencies and description (when found)
+ *
+ * All unique module resolutions are performed in parallel.
+ */
+export async function enrichModuleTasks(tasks: PsakeTaskInfo[], resolver: PsakeModuleResolver): Promise<void> {
+  const moduleItems = tasks.filter(t => !!t.fromModule);
+  if (moduleItems.length === 0) {
+    return;
+  }
+
+  await Promise.all(
+    moduleItems.map(async info => {
+      const constraints: VersionConstraints = {
+        requiredVersion: info.requiredVersion,
+        minimumVersion: info.minimumVersion,
+        maximumVersion: info.maximumVersion,
+        lessThanVersion: info.lessThanVersion,
+      };
+
+      const moduleTasks = await resolver.resolveModuleTasks(info.fromModule!, constraints);
+      info.moduleResolved = moduleTasks.length > 0;
+
+      if (info.moduleResolved) {
+        const moduleTask = moduleTasks.find(
+          t => t.name.toLowerCase() === info.name.toLowerCase()
+        );
+        if (moduleTask) {
+          if (!info.description) {
+            info.description = moduleTask.description;
+          }
+          // Merge deps: local deps (if any) plus the module task's deps.
+          info.dependencies = [...new Set([...info.dependencies, ...moduleTask.dependencies])];
+        }
+      }
+    })
+  );
+}

--- a/src/moduleResolver.ts
+++ b/src/moduleResolver.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { parsePsakeFile, PsakeTaskInfo } from './psakeParser.js';
+import { parsePsakeFile, parseIncludes, PsakeTaskInfo, PsakeIncludeInfo } from './psakeParser.js';
 import { detectPowerShellExecutable, runPowerShellScript } from './powershellUtils.js';
 import { logError } from './log.js';
 
@@ -127,7 +127,13 @@ export class PsakeModuleResolver {
       const uri = vscode.Uri.file(psakeFilePath);
       const bytes = await vscode.workspace.fs.readFile(uri);
       const content = Buffer.from(bytes).toString('utf8');
-      return parsePsakeFile(content);
+      const tasks = parsePsakeFile(content);
+      // Stamp every task with the file it came from so callers can navigate to
+      // the correct source (the module's psakeFile.ps1, not the main psakefile).
+      for (const t of tasks) {
+        t.sourceFilePath = psakeFilePath;
+      }
+      return tasks;
     } catch {
       // Module exists but has no psakeFile.ps1 — not a psake task module.
       return [];
@@ -141,9 +147,9 @@ export class PsakeModuleResolver {
     const safeName = moduleName.replace(/'/g, "''");
     const script = [
       `Get-Module -Name '${safeName}' -ListAvailable -ErrorAction SilentlyContinue`,
-      `| Select-Object -Property ModuleBase, @{N='Version';E={$_.Version.ToString()}}`,
-      `| ConvertTo-Json -Compress`,
-    ].join(' ');
+      `Select-Object -Property ModuleBase, @{N='Version';E={$_.Version.ToString()}}`,
+      `ConvertTo-Json -Compress`,
+    ].join(' | ');
 
     let output: string;
     try {
@@ -218,4 +224,137 @@ export async function enrichModuleTasks(tasks: PsakeTaskInfo[], resolver: PsakeM
       }
     })
   );
+}
+
+// ---------------------------------------------------------------------------
+// Include file resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Reads every included file, parses its tasks, and stamps each task with
+ * `includedFrom` (display path) and `sourceFilePath` (absolute path).
+ */
+async function resolveIncludedTasks(
+  includes: PsakeIncludeInfo[],
+  buildFileUri: vscode.Uri,
+): Promise<PsakeTaskInfo[]> {
+  const buildDir = path.dirname(buildFileUri.fsPath);
+  const result: PsakeTaskInfo[] = [];
+
+  for (const include of includes) {
+    const absolutePath = path.isAbsolute(include.path)
+      ? include.path
+      : path.resolve(buildDir, include.path);
+
+    try {
+      const uri = vscode.Uri.file(absolutePath);
+      const bytes = await vscode.workspace.fs.readFile(uri);
+      const content = Buffer.from(bytes).toString('utf8');
+      const tasks = parsePsakeFile(content);
+      const displayPath = path.relative(buildDir, absolutePath).replace(/\\/g, '/');
+      for (const t of tasks) {
+        t.includedFrom = displayPath;
+        t.sourceFilePath = absolutePath;
+      }
+      result.push(...tasks);
+    } catch {
+      // Include file not found or unreadable — skip silently.
+    }
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Full resolution: local + includes + module expansion
+// ---------------------------------------------------------------------------
+
+/**
+ * The main resolution entry point used by the tree view, task provider, and
+ * completion provider.
+ *
+ * Returns the full set of tasks visible to the build:
+ *  1. Tasks declared directly in the psakefile (with module references enriched).
+ *  2. Tasks from every `Include`-d file (deduplicated against local).
+ *  3. All tasks exported by each loaded module that are NOT already declared
+ *     locally — these become available in the psake build context because psake
+ *     dot-sources the entire module psakeFile.ps1 (deduplicated against 1 & 2).
+ *
+ * Local declarations always win over included > module-expanded.
+ */
+export async function resolveAllTasks(
+  content: string,
+  buildFileUri: vscode.Uri,
+  resolver?: PsakeModuleResolver,
+): Promise<PsakeTaskInfo[]> {
+  // 1. Parse the psakefile
+  const localTasks = parsePsakeFile(content);
+  const includes = parseIncludes(content);
+
+  // 2. Enrich local module-reference tasks (sets moduleResolved, merges deps/description)
+  if (resolver) {
+    await enrichModuleTasks(localTasks, resolver);
+  }
+
+  // 3. Expand: add every task from each resolved module that isn't already
+  //    declared locally (psake dot-sources the whole module psakeFile.ps1).
+  const expandedModuleTasks: PsakeTaskInfo[] = [];
+  if (resolver) {
+    // Collect unique modules, preserving original casing from the first reference.
+    const moduleRefs = new Map<string, { originalName: string; constraints: VersionConstraints }>();
+    for (const task of localTasks) {
+      if (task.fromModule && task.moduleResolved !== false) {
+        const key = task.fromModule.toLowerCase();
+        if (!moduleRefs.has(key)) {
+          moduleRefs.set(key, {
+            originalName: task.fromModule,
+            constraints: {
+              requiredVersion: task.requiredVersion,
+              minimumVersion: task.minimumVersion,
+              maximumVersion: task.maximumVersion,
+              lessThanVersion: task.lessThanVersion,
+            },
+          });
+        }
+      }
+    }
+
+    const localNames = new Set(localTasks.map(t => t.name.toLowerCase()));
+    for (const { originalName, constraints } of moduleRefs.values()) {
+      // resolveModuleTasks is cached — this is a fast lookup after enrichModuleTasks.
+      const moduleTasks = await resolver.resolveModuleTasks(originalName, constraints);
+      for (const mt of moduleTasks) {
+        if (!localNames.has(mt.name.toLowerCase())) {
+          localNames.add(mt.name.toLowerCase());
+          mt.fromModule = originalName;
+          mt.moduleResolved = true;
+          expandedModuleTasks.push(mt);
+        }
+      }
+    }
+  }
+
+  // 4. Resolve included files
+  const includedTasks = await resolveIncludedTasks(includes, buildFileUri);
+
+  // 5. Deduplicate: local > included > module-expanded
+  const seen = new Set(localTasks.map(t => t.name.toLowerCase()));
+
+  const finalIncluded: PsakeTaskInfo[] = [];
+  for (const t of includedTasks) {
+    if (!seen.has(t.name.toLowerCase())) {
+      seen.add(t.name.toLowerCase());
+      finalIncluded.push(t);
+    }
+  }
+
+  const finalModule: PsakeTaskInfo[] = [];
+  for (const t of expandedModuleTasks) {
+    if (!seen.has(t.name.toLowerCase())) {
+      seen.add(t.name.toLowerCase());
+      finalModule.push(t);
+    }
+  }
+
+  return [...localTasks, ...finalIncluded, ...finalModule];
 }

--- a/src/powershellUtils.ts
+++ b/src/powershellUtils.ts
@@ -26,12 +26,40 @@ export async function detectPowerShellExecutable(): Promise<string> {
   return 'pwsh';
 }
 
+/**
+ * Builds a spawn environment where PSModulePath is sourced from the Windows
+ * machine-level registry entry, avoiding the mixture of PS5/PS7 paths that
+ * VS Code may have injected into the process environment.
+ * Falls back to deleting PSModulePath (letting PowerShell self-initialize) if
+ * the registry query fails or the host is not Windows.
+ */
+function buildSpawnEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  if (process.platform === 'win32') {
+    try {
+      const out = childProcess.execSync(
+        'reg query "HKLM\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment" /v PSModulePath',
+        { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }
+      );
+      const match = out.match(/PSModulePath\s+REG[^\s]*\s+(.+)/i);
+      if (match?.[1]) {
+        // REG_EXPAND_SZ values contain unexpanded %VAR% references — expand them.
+        env['PSModulePath'] = match[1].trim().replace(/%([^%]+)%/g, (_, name) => process.env[name] ?? `%${name}%`);
+        return env;
+      }
+    } catch { /* fall through to delete */ }
+  }
+  delete env['PSModulePath'];
+  return env;
+}
+
 export function testExecutable(executable: string): Promise<boolean> {
   return new Promise<boolean>(resolve => {
+    const env = buildSpawnEnv();
     const ps = childProcess.spawn(
       executable,
       ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', 'Write-Host "OK"'],
-      { shell: true }
+      { shell: true, env }
     );
 
     let hasOutput = false;
@@ -46,11 +74,12 @@ export function testExecutable(executable: string): Promise<boolean> {
  * Rejects if the process exits with a non-zero code.
  */
 export function runPowerShellScript(executable: string, script: string): Promise<string> {
+  const env = buildSpawnEnv();
   return new Promise<string>((resolve, reject) => {
     const ps = childProcess.spawn(
       executable,
-      ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', script],
-      { shell: true }
+      ['-NoLogo', '-NoProfile', '-NonInteractive', '-EncodedCommand', Buffer.from(script, 'utf16le').toString('base64')],
+      { shell: true, env }
     );
 
     let stdout = '';

--- a/src/powershellUtils.ts
+++ b/src/powershellUtils.ts
@@ -1,0 +1,69 @@
+import * as childProcess from 'child_process';
+import * as vscode from 'vscode';
+
+/**
+ * Detects and returns the best available PowerShell executable.
+ *
+ * Resolution order:
+ * 1. `psake.powershellExecutable` configuration value (if set)
+ * 2. `pwsh` (PowerShell 7+), if found on PATH
+ * 3. `powershell` (Windows PowerShell 5.1), if found on PATH
+ * 4. Falls back to `pwsh` and lets any error surface at runtime.
+ */
+export async function detectPowerShellExecutable(): Promise<string> {
+  const config = vscode.workspace.getConfiguration('psake');
+  const configured: string = config.get('powershellExecutable') ?? '';
+  if (configured) {
+    return configured;
+  }
+
+  for (const exe of ['pwsh', 'powershell']) {
+    if (await testExecutable(exe)) {
+      return exe;
+    }
+  }
+
+  return 'pwsh';
+}
+
+export function testExecutable(executable: string): Promise<boolean> {
+  return new Promise<boolean>(resolve => {
+    const ps = childProcess.spawn(
+      executable,
+      ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', 'Write-Host "OK"'],
+      { shell: true }
+    );
+
+    let hasOutput = false;
+    ps.stdout.on('data', () => { hasOutput = true; });
+    ps.on('close', (code: number) => resolve(code === 0 && hasOutput));
+    ps.on('error', () => resolve(false));
+  });
+}
+
+/**
+ * Spawns a PowerShell process and returns its stdout as a trimmed string.
+ * Rejects if the process exits with a non-zero code.
+ */
+export function runPowerShellScript(executable: string, script: string): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    const ps = childProcess.spawn(
+      executable,
+      ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', script],
+      { shell: true }
+    );
+
+    let stdout = '';
+    let stderr = '';
+    ps.stdout.on('data', (data: Buffer) => { stdout += data.toString(); });
+    ps.stderr.on('data', (data: Buffer) => { stderr += data.toString(); });
+    ps.on('close', (code: number) => {
+      if (code === 0) {
+        resolve(stdout.trim());
+      } else {
+        reject(new Error(`PowerShell exited ${code}: ${stderr.trim()}`));
+      }
+    });
+    ps.on('error', reject);
+  });
+}

--- a/src/psakeParser.ts
+++ b/src/psakeParser.ts
@@ -6,6 +6,20 @@ export interface PsakeTaskInfo {
     description: string;
     /** Zero-based line number where the Task declaration begins */
     line: number;
+    /** Module name supplied via the -FromModule parameter (SharedTask parameter set) */
+    fromModule?: string;
+    /** Version constraints for the -FromModule module */
+    requiredVersion?: string;
+    minimumVersion?: string;
+    maximumVersion?: string;
+    lessThanVersion?: string;
+    /**
+     * Populated by the module resolver after attempting to locate the named module.
+     * true  = module found and task metadata merged.
+     * false = module not found or version constraint not satisfied.
+     * undefined = task has no -FromModule, or resolution hasn't been run yet.
+     */
+    moduleResolved?: boolean;
 }
 
 /**
@@ -118,8 +132,13 @@ function parseTaskLine(line: string, lineIndex: number): PsakeTaskInfo | null {
 
     const dependencies = extractDepends(rest);
     const description = extractDescription(rest);
+    const fromModule = extractFromModule(rest) ?? undefined;
+    const requiredVersion = (extractVersionParam(rest, 'RequiredVersion') ?? extractVersionParam(rest, 'Version')) ?? undefined;
+    const minimumVersion = extractVersionParam(rest, 'MinimumVersion') ?? undefined;
+    const maximumVersion = extractVersionParam(rest, 'MaximumVersion') ?? undefined;
+    const lessThanVersion = extractVersionParam(rest, 'LessThanVersion') ?? undefined;
 
-    return { name, dependencies, description, line: lineIndex };
+    return { name, dependencies, description, line: lineIndex, fromModule, requiredVersion, minimumVersion, maximumVersion, lessThanVersion };
 }
 
 /** Matches a possibly-quoted identifier */
@@ -157,4 +176,17 @@ function extractDescription(rest: string): string {
     // -Description "some text" or -Description 'some text'
     const match = rest.match(/-Description\s+["']([^"']*)["']/i);
     return match ? match[1] : '';
+}
+
+function extractFromModule(rest: string): string | null {
+    // -FromModule ModuleName  or  -FromModule 'ModuleName'  or  -FromModule "ModuleName"
+    const match = rest.match(/-FromModule\s+["']?([A-Za-z0-9_.\-]+)["']?/i);
+    return match ? match[1] : null;
+}
+
+function extractVersionParam(rest: string, paramName: string): string | null {
+    // Handles -MinimumVersion '1.2.3', -RequiredVersion "1.2.3", -Version 1.2.3, etc.
+    const escaped = paramName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const match = rest.match(new RegExp(`-${escaped}\\s+["']?([\\w.]+)["']?`, 'i'));
+    return match ? match[1] : null;
 }

--- a/src/psakeParser.ts
+++ b/src/psakeParser.ts
@@ -20,6 +20,31 @@ export interface PsakeTaskInfo {
      * undefined = task has no -FromModule, or resolution hasn't been run yet.
      */
     moduleResolved?: boolean;
+    /**
+     * Set when the task was discovered from an `Include`-d file rather than the
+     * main psakefile.  Holds the path as written in the Include statement
+     * (relative or absolute), used for display purposes.
+     */
+    includedFrom?: string;
+    /**
+     * Absolute file-system path to the file where this task is defined.
+     * Populated for tasks from modules and Include files so that the
+     * "Go to Task Definition" command opens the correct source file.
+     * Undefined for tasks declared directly in the main psakefile.
+     */
+    sourceFilePath?: string;
+}
+
+/**
+ * Represents an `Include` statement found in a psakefile.
+ */
+export interface PsakeIncludeInfo {
+    /** The path as written in the Include statement (may be relative or absolute). */
+    path: string;
+    /** True when the -LiteralPath parameter was used. */
+    isLiteral: boolean;
+    /** Zero-based line number of the Include statement. */
+    line: number;
 }
 
 /**
@@ -189,4 +214,66 @@ function extractVersionParam(rest: string, paramName: string): string | null {
     const escaped = paramName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     const match = rest.match(new RegExp(`-${escaped}\\s+["']?([\\w.]+)["']?`, 'i'));
     return match ? match[1] : null;
+}
+
+// ---------------------------------------------------------------------------
+// Include parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parses all `Include` statements from a psakefile.
+ *
+ * Handles these forms (all case-insensitive, with or without quotes):
+ *
+ *   Include './helpers.ps1'
+ *   Include -Path './helpers.ps1'
+ *   Include -fileNamePathToInclude './helpers.ps1'
+ *   Include -LiteralPath './helpers.ps1'
+ */
+export function parseIncludes(content: string): PsakeIncludeInfo[] {
+    const result: PsakeIncludeInfo[] = [];
+    const lines = content.split(/\r?\n/);
+    const joined = joinContinuationLines(lines);
+
+    for (const { text, originalLine } of joined) {
+        const trimmed = text.trimStart();
+        if (!trimmed || trimmed.startsWith('#')) {
+            continue;
+        }
+        const info = parseIncludeLine(trimmed, originalLine);
+        if (info) {
+            result.push(info);
+        }
+    }
+
+    return result;
+}
+
+function parseIncludeLine(line: string, lineIndex: number): PsakeIncludeInfo | null {
+    if (!/^Include\s+/i.test(line)) {
+        return null;
+    }
+    const rest = line.replace(/^Include\s+/i, '').trim();
+
+    // -LiteralPath
+    const literalMatch = rest.match(/^-LiteralPath\s+["']?([^"'\s]+)["']?/i);
+    if (literalMatch) {
+        return { path: literalMatch[1], isLiteral: true, line: lineIndex };
+    }
+
+    // -Path or -fileNamePathToInclude (named parameter)
+    const namedMatch = rest.match(/^-(?:Path|fileNamePathToInclude)\s+["']?([^"'\s]+)["']?/i);
+    if (namedMatch) {
+        return { path: namedMatch[1], isLiteral: false, line: lineIndex };
+    }
+
+    // Positional: must not start with '-' (that would be an unknown param)
+    if (!rest.startsWith('-')) {
+        const posMatch = rest.match(/^["']?([^"'\s]+)["']?/);
+        if (posMatch) {
+            return { path: posMatch[1], isLiteral: false, line: lineIndex };
+        }
+    }
+
+    return null;
 }

--- a/src/taskProvider.ts
+++ b/src/taskProvider.ts
@@ -1,10 +1,10 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { findPsakeFiles, parsePsakeFile } from './psakeParser.js';
+import { findPsakeFiles } from './psakeParser.js';
 import { TASK_TYPE } from './constants.js';
 import { logError } from './log.js';
 import { detectPowerShellExecutable } from './powershellUtils.js';
-import { PsakeModuleResolver, enrichModuleTasks } from './moduleResolver.js';
+import { PsakeModuleResolver, resolveAllTasks } from './moduleResolver.js';
 
 export interface PsakeTaskDefinition extends vscode.TaskDefinition {
     type: 'psake';
@@ -182,10 +182,7 @@ export class PsakeTaskProvider implements vscode.TaskProvider {
                 try {
                     const bytes = await vscode.workspace.fs.readFile(uri);
                     const content = Buffer.from(bytes).toString('utf8');
-                    const psakeTaskInfos = parsePsakeFile(content);
-                    if (this.resolver) {
-                        await enrichModuleTasks(psakeTaskInfos, this.resolver);
-                    }
+                    const psakeTaskInfos = await resolveAllTasks(content, uri, this.resolver);
                     const relativeFile = path.relative(folder.uri.fsPath, uri.fsPath);
 
                     for (const info of psakeTaskInfos) {

--- a/src/taskProvider.ts
+++ b/src/taskProvider.ts
@@ -1,9 +1,10 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
-import * as childProcess from 'child_process';
 import { findPsakeFiles, parsePsakeFile } from './psakeParser.js';
 import { TASK_TYPE } from './constants.js';
 import { logError } from './log.js';
+import { detectPowerShellExecutable } from './powershellUtils.js';
+import { PsakeModuleResolver, enrichModuleTasks } from './moduleResolver.js';
 
 export interface PsakeTaskDefinition extends vscode.TaskDefinition {
     type: 'psake';
@@ -19,8 +20,10 @@ export class PsakeTaskProvider implements vscode.TaskProvider {
     private detectedExecutable: string | undefined;
     /** Cached build script path per workspace folder URI */
     private buildScriptCache = new Map<string, string | undefined>();
+    private readonly resolver: PsakeModuleResolver | undefined;
 
-    constructor(watcher: vscode.FileSystemWatcher) {
+    constructor(watcher: vscode.FileSystemWatcher, resolver?: PsakeModuleResolver) {
+        this.resolver = resolver;
         this.bindWatcher(watcher);
     }
 
@@ -48,7 +51,7 @@ export class PsakeTaskProvider implements vscode.TaskProvider {
         }
         // Detect the PowerShell executable before building tasks so the
         // cached result is available for buildTask (which is synchronous).
-        await this.detectPowerShellExecutable();
+        await this.getExecutable();
         this.cachedTasks = await this.detectTasks();
         return this.cachedTasks;
     }
@@ -90,48 +93,13 @@ export class PsakeTaskProvider implements vscode.TaskProvider {
     // PowerShell executable detection
     // -------------------------------------------------------------------------
 
-    /**
-     * Detects which PowerShell executable is available on the system.
-     * Prefers pwsh (PowerShell 7+), falls back to powershell (Windows PowerShell 5.1).
-     * Caches the result for the lifetime of the provider.
-     */
-    private async detectPowerShellExecutable(): Promise<string> {
+    /** Returns the cached PowerShell executable, detecting it on first call. */
+    private async getExecutable(): Promise<string> {
         if (this.detectedExecutable) {
             return this.detectedExecutable;
         }
-
-        const config = vscode.workspace.getConfiguration('psake');
-        const configured: string = config.get('powershellExecutable') ?? '';
-        if (configured) {
-            this.detectedExecutable = configured;
-            return configured;
-        }
-
-        const candidates = ['pwsh', 'powershell'];
-        for (const exe of candidates) {
-            if (await this.testExecutable(exe)) {
-                this.detectedExecutable = exe;
-                return exe;
-            }
-        }
-
-        // Fall back to pwsh and let the error surface when the task runs
-        return 'pwsh';
-    }
-
-    private testExecutable(executable: string): Promise<boolean> {
-        return new Promise<boolean>(resolve => {
-            const ps = childProcess.spawn(
-                executable,
-                ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', 'Write-Host "OK"'],
-                { shell: true }
-            );
-
-            let hasOutput = false;
-            ps.stdout.on('data', () => { hasOutput = true; });
-            ps.on('close', (code: number) => resolve(code === 0 && hasOutput));
-            ps.on('error', () => resolve(false));
-        });
+        this.detectedExecutable = await detectPowerShellExecutable();
+        return this.detectedExecutable;
     }
 
     // -------------------------------------------------------------------------
@@ -167,8 +135,8 @@ export class PsakeTaskProvider implements vscode.TaskProvider {
             // Auto-detect build.ps1 in workspace root (case-insensitive)
             try {
                 const files = await vscode.workspace.fs.readDirectory(folder.uri);
-                const buildFile = files.find(([name, type]) => 
-                    type === vscode.FileType.File && 
+                const buildFile = files.find(([name, type]) =>
+                    type === vscode.FileType.File &&
                     name.toLowerCase() === 'build.ps1'
                 );
                 result = buildFile ? buildFile[0] : undefined;
@@ -215,6 +183,9 @@ export class PsakeTaskProvider implements vscode.TaskProvider {
                     const bytes = await vscode.workspace.fs.readFile(uri);
                     const content = Buffer.from(bytes).toString('utf8');
                     const psakeTaskInfos = parsePsakeFile(content);
+                    if (this.resolver) {
+                        await enrichModuleTasks(psakeTaskInfos, this.resolver);
+                    }
                     const relativeFile = path.relative(folder.uri.fsPath, uri.fsPath);
 
                     for (const info of psakeTaskInfos) {
@@ -250,8 +221,7 @@ export class PsakeTaskProvider implements vscode.TaskProvider {
             ? buildBuildScriptCommand(buildScript, def.task, config.get('buildScriptTaskParameter') ?? 'Task', extraScriptParams)
             : buildInvokePsakeCommand(buildFile, def.task, extraInvokeParams);
 
-        // Use the detected executable asynchronously; fall back to pwsh
-        // if detection hasn't completed yet (resolveTask is sync).
+        // Use the already-detected executable; fall back to pwsh if not yet detected.
         const executable = this.detectedExecutable ?? 'pwsh';
         const extraShellArgs: string[] = config.get('shellArgs') ?? ['-NoProfile'];
 

--- a/src/tasksJsonCompletionProvider.ts
+++ b/src/tasksJsonCompletionProvider.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
-import { findPsakeFiles, parsePsakeFile, PsakeTaskInfo } from './psakeParser.js';
-import { PsakeModuleResolver, enrichModuleTasks } from './moduleResolver.js';
+import { findPsakeFiles, PsakeTaskInfo } from './psakeParser.js';
+import { PsakeModuleResolver, resolveAllTasks } from './moduleResolver.js';
 import { logError } from './log.js';
 
 /**
@@ -148,10 +148,7 @@ export class PsakeTaskCompletionProvider implements vscode.CompletionItemProvide
             for (const uri of uris) {
                 const bytes = await vscode.workspace.fs.readFile(uri);
                 const content = Buffer.from(bytes).toString('utf8');
-                tasks.push(...parsePsakeFile(content));
-            }
-            if (this.resolver) {
-                await enrichModuleTasks(tasks, this.resolver);
+                tasks.push(...await resolveAllTasks(content, uri, this.resolver));
             }
         } catch (err) {
             logError(err, false);

--- a/src/tasksJsonCompletionProvider.ts
+++ b/src/tasksJsonCompletionProvider.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { findPsakeFiles, parsePsakeFile, PsakeTaskInfo } from './psakeParser.js';
+import { PsakeModuleResolver, enrichModuleTasks } from './moduleResolver.js';
 import { logError } from './log.js';
 
 /**
@@ -14,8 +15,10 @@ export class PsakeTaskCompletionProvider implements vscode.CompletionItemProvide
     private cachedTasks: PsakeTaskInfo[] | undefined;
     private cacheTime = 0;
     private static readonly CACHE_TTL_MS = 5000;
+    private readonly resolver: PsakeModuleResolver | undefined;
 
-    constructor(watcher: vscode.FileSystemWatcher) {
+    constructor(watcher: vscode.FileSystemWatcher, resolver?: PsakeModuleResolver) {
+        this.resolver = resolver;
         const invalidate = (): void => { this.cachedTasks = undefined; };
         watcher.onDidChange(invalidate);
         watcher.onDidCreate(invalidate);
@@ -46,10 +49,20 @@ export class PsakeTaskCompletionProvider implements vscode.CompletionItemProvide
             item.detail = info.description || `psake task`;
             item.sortText = String(index).padStart(4, '0');
 
+            const docParts: string[] = [];
+            if (info.fromModule) {
+                docParts.push(`**From module:** \`${info.fromModule}\``);
+                if (info.requiredVersion) { docParts.push(`Required version: ${info.requiredVersion}`); }
+                if (info.minimumVersion) { docParts.push(`Minimum version: ≥ ${info.minimumVersion}`); }
+                if (info.maximumVersion) { docParts.push(`Maximum version: ≤ ${info.maximumVersion}`); }
+                if (info.lessThanVersion) { docParts.push(`Less than version: ${info.lessThanVersion}`); }
+                if (info.moduleResolved === false) { docParts.push(`⚠ Module not found or version constraint not satisfied.`); }
+            }
             if (info.dependencies.length > 0) {
-                item.documentation = new vscode.MarkdownString(
-                    `**Depends on:** ${info.dependencies.join(', ')}`
-                );
+                docParts.push(`**Depends on:** ${info.dependencies.join(', ')}`);
+            }
+            if (docParts.length > 0) {
+                item.documentation = new vscode.MarkdownString(docParts.join('\n\n'));
             }
 
             return item;
@@ -136,6 +149,9 @@ export class PsakeTaskCompletionProvider implements vscode.CompletionItemProvide
                 const bytes = await vscode.workspace.fs.readFile(uri);
                 const content = Buffer.from(bytes).toString('utf8');
                 tasks.push(...parsePsakeFile(content));
+            }
+            if (this.resolver) {
+                await enrichModuleTasks(tasks, this.resolver);
             }
         } catch (err) {
             logError(err, false);

--- a/src/test/moduleResolver.test.ts
+++ b/src/test/moduleResolver.test.ts
@@ -1,0 +1,153 @@
+import * as assert from 'assert';
+import { matchesVersionConstraints } from '../moduleResolver.js';
+
+suite('moduleResolver', () => {
+  suite('matchesVersionConstraints', () => {
+    test('returns true when no constraints are specified', () => {
+      assert.strictEqual(matchesVersionConstraints('1.0.0', {}), true);
+      assert.strictEqual(matchesVersionConstraints('0.0.1', {}), true);
+    });
+
+    suite('requiredVersion (exact match)', () => {
+      test('matches exact version', () => {
+        assert.strictEqual(matchesVersionConstraints('1.2.3', { requiredVersion: '1.2.3' }), true);
+      });
+
+      test('rejects lower version', () => {
+        assert.strictEqual(matchesVersionConstraints('1.2.2', { requiredVersion: '1.2.3' }), false);
+      });
+
+      test('rejects higher version', () => {
+        assert.strictEqual(matchesVersionConstraints('1.2.4', { requiredVersion: '1.2.3' }), false);
+      });
+    });
+
+    suite('minimumVersion (inclusive >=)', () => {
+      test('accepts version equal to minimum', () => {
+        assert.strictEqual(matchesVersionConstraints('0.6.1', { minimumVersion: '0.6.1' }), true);
+      });
+
+      test('accepts version above minimum', () => {
+        assert.strictEqual(matchesVersionConstraints('1.0.0', { minimumVersion: '0.6.1' }), true);
+      });
+
+      test('rejects version below minimum', () => {
+        assert.strictEqual(matchesVersionConstraints('0.5.9', { minimumVersion: '0.6.1' }), false);
+      });
+    });
+
+    suite('maximumVersion (inclusive <=)', () => {
+      test('accepts version equal to maximum', () => {
+        assert.strictEqual(matchesVersionConstraints('1.0.0', { maximumVersion: '1.0.0' }), true);
+      });
+
+      test('accepts version below maximum', () => {
+        assert.strictEqual(matchesVersionConstraints('0.9.9', { maximumVersion: '1.0.0' }), true);
+      });
+
+      test('rejects version above maximum', () => {
+        assert.strictEqual(matchesVersionConstraints('1.0.1', { maximumVersion: '1.0.0' }), false);
+      });
+    });
+
+    suite('lessThanVersion (exclusive <)', () => {
+      test('accepts version strictly below the limit', () => {
+        assert.strictEqual(matchesVersionConstraints('1.9.9', { lessThanVersion: '2.0.0' }), true);
+      });
+
+      test('rejects version equal to the limit', () => {
+        assert.strictEqual(matchesVersionConstraints('2.0.0', { lessThanVersion: '2.0.0' }), false);
+      });
+
+      test('rejects version above the limit', () => {
+        assert.strictEqual(matchesVersionConstraints('2.0.1', { lessThanVersion: '2.0.0' }), false);
+      });
+    });
+
+    suite('combined constraints (range)', () => {
+      test('accepts version within min..max range', () => {
+        assert.strictEqual(
+          matchesVersionConstraints('0.7.0', { minimumVersion: '0.5.0', maximumVersion: '1.0.0' }),
+          true
+        );
+      });
+
+      test('accepts version at lower bound', () => {
+        assert.strictEqual(
+          matchesVersionConstraints('0.5.0', { minimumVersion: '0.5.0', maximumVersion: '1.0.0' }),
+          true
+        );
+      });
+
+      test('accepts version at upper bound', () => {
+        assert.strictEqual(
+          matchesVersionConstraints('1.0.0', { minimumVersion: '0.5.0', maximumVersion: '1.0.0' }),
+          true
+        );
+      });
+
+      test('rejects version below lower bound', () => {
+        assert.strictEqual(
+          matchesVersionConstraints('0.4.9', { minimumVersion: '0.5.0', maximumVersion: '1.0.0' }),
+          false
+        );
+      });
+
+      test('rejects version above upper bound', () => {
+        assert.strictEqual(
+          matchesVersionConstraints('1.0.1', { minimumVersion: '0.5.0', maximumVersion: '1.0.0' }),
+          false
+        );
+      });
+
+      test('accepts version within minimumVersion + lessThanVersion window', () => {
+        assert.strictEqual(
+          matchesVersionConstraints('0.2.9', { minimumVersion: '0.2.0', lessThanVersion: '0.3.0' }),
+          true
+        );
+      });
+
+      test('rejects version at the lessThanVersion boundary', () => {
+        assert.strictEqual(
+          matchesVersionConstraints('0.3.0', { minimumVersion: '0.2.0', lessThanVersion: '0.3.0' }),
+          false
+        );
+      });
+    });
+
+    suite('multi-segment version comparisons', () => {
+      test('correctly compares versions with differing segment counts', () => {
+        assert.strictEqual(matchesVersionConstraints('1.0', { minimumVersion: '1.0.0' }), true);
+        assert.strictEqual(matchesVersionConstraints('1.0.0', { minimumVersion: '1.0' }), true);
+      });
+
+      test('handles four-part versions', () => {
+        assert.strictEqual(
+          matchesVersionConstraints('1.0.0.1', { minimumVersion: '1.0.0.0', maximumVersion: '1.0.0.5' }),
+          true
+        );
+        assert.strictEqual(
+          matchesVersionConstraints('1.0.0.6', { minimumVersion: '1.0.0.0', maximumVersion: '1.0.0.5' }),
+          false
+        );
+      });
+    });
+
+    suite('requiredVersion takes precedence over other constraints', () => {
+      test('requiredVersion is checked exclusively, ignoring minimumVersion', () => {
+        // requiredVersion match — should return true regardless that minimumVersion is also given
+        assert.strictEqual(
+          matchesVersionConstraints('1.0.0', { requiredVersion: '1.0.0', minimumVersion: '0.5.0' }),
+          true
+        );
+      });
+
+      test('requiredVersion mismatch returns false even if min/max would accept', () => {
+        assert.strictEqual(
+          matchesVersionConstraints('1.0.1', { requiredVersion: '1.0.0', minimumVersion: '0.5.0' }),
+          false
+        );
+      });
+    });
+  });
+});

--- a/src/test/psakeParser.test.ts
+++ b/src/test/psakeParser.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { parsePsakeFile } from '../psakeParser.js';
+import { parsePsakeFile, parseIncludes } from '../psakeParser.js';
 
 suite('psakeParser', () => {
     suite('parsePsakeFile', () => {
@@ -216,6 +216,87 @@ suite('psakeParser', () => {
             const tasks = parsePsakeFile(content);
             assert.strictEqual(tasks[0].fromModule, undefined);
             assert.strictEqual(tasks[0].minimumVersion, undefined);
+        });
+    });
+
+    suite('parseIncludes', () => {
+        test('parses positional Include', () => {
+            const content = `Include './helpers.ps1'`;
+            const includes = parseIncludes(content);
+            assert.strictEqual(includes.length, 1);
+            assert.strictEqual(includes[0].path, './helpers.ps1');
+            assert.strictEqual(includes[0].isLiteral, false);
+            assert.strictEqual(includes[0].line, 0);
+        });
+
+        test('parses positional Include with double quotes', () => {
+            const content = `Include "./helpers.ps1"`;
+            const includes = parseIncludes(content);
+            assert.strictEqual(includes[0].path, './helpers.ps1');
+        });
+
+        test('parses -Path parameter', () => {
+            const content = `Include -Path './helpers.ps1'`;
+            const includes = parseIncludes(content);
+            assert.strictEqual(includes[0].path, './helpers.ps1');
+            assert.strictEqual(includes[0].isLiteral, false);
+        });
+
+        test('parses -fileNamePathToInclude alias', () => {
+            const content = `Include -fileNamePathToInclude './helpers.ps1'`;
+            const includes = parseIncludes(content);
+            assert.strictEqual(includes[0].path, './helpers.ps1');
+            assert.strictEqual(includes[0].isLiteral, false);
+        });
+
+        test('parses -LiteralPath parameter and sets isLiteral = true', () => {
+            const content = `Include -LiteralPath 'C:\\build\\helpers.ps1'`;
+            const includes = parseIncludes(content);
+            assert.strictEqual(includes[0].path, 'C:\\build\\helpers.ps1');
+            assert.strictEqual(includes[0].isLiteral, true);
+        });
+
+        test('parses multiple Include statements', () => {
+            const content = [
+                `Include './helpers.ps1'`,
+                `Task Build { }`,
+                `Include -Path './tools.ps1'`,
+            ].join('\n');
+            const includes = parseIncludes(content);
+            assert.strictEqual(includes.length, 2);
+            assert.strictEqual(includes[0].path, './helpers.ps1');
+            assert.strictEqual(includes[0].line, 0);
+            assert.strictEqual(includes[1].path, './tools.ps1');
+            assert.strictEqual(includes[1].line, 2);
+        });
+
+        test('parses Include on continuation lines', () => {
+            const content = [
+                'Include `',
+                "    './helpers.ps1'",
+            ].join('\n');
+            const includes = parseIncludes(content);
+            assert.strictEqual(includes.length, 1);
+            assert.strictEqual(includes[0].path, './helpers.ps1');
+        });
+
+        test('ignores comment lines', () => {
+            const content = `# Include './ignored.ps1'\nInclude './real.ps1'`;
+            const includes = parseIncludes(content);
+            assert.strictEqual(includes.length, 1);
+            assert.strictEqual(includes[0].path, './real.ps1');
+        });
+
+        test('returns empty array when no Include statements', () => {
+            const content = `Task Build { }\nTask Clean { }`;
+            assert.deepStrictEqual(parseIncludes(content), []);
+        });
+
+        test('is case-insensitive for the Include keyword', () => {
+            const content = `include './helpers.ps1'`;
+            const includes = parseIncludes(content);
+            assert.strictEqual(includes.length, 1);
+            assert.strictEqual(includes[0].path, './helpers.ps1');
         });
     });
 });

--- a/src/test/psakeParser.test.ts
+++ b/src/test/psakeParser.test.ts
@@ -137,4 +137,85 @@ suite('psakeParser', () => {
             assert.strictEqual(tasks[0].name, 'Real');
         });
     });
+
+    suite('FromModule tasks', () => {
+        test('parses -FromModule parameter', () => {
+            const content = `Task Test -FromModule PowerShellBuild`;
+            const tasks = parsePsakeFile(content);
+            assert.strictEqual(tasks.length, 1);
+            assert.strictEqual(tasks[0].name, 'Test');
+            assert.strictEqual(tasks[0].fromModule, 'PowerShellBuild');
+            assert.strictEqual(tasks[0].minimumVersion, undefined);
+            assert.strictEqual(tasks[0].requiredVersion, undefined);
+        });
+
+        test('parses -FromModule with -minimumVersion', () => {
+            const content = `Task Test -FromModule PowerShellBuild -minimumVersion '0.6.1'`;
+            const tasks = parsePsakeFile(content);
+            assert.strictEqual(tasks[0].fromModule, 'PowerShellBuild');
+            assert.strictEqual(tasks[0].minimumVersion, '0.6.1');
+        });
+
+        test('parses -FromModule with -requiredVersion', () => {
+            const content = `Task Test -FromModule PowerShellBuild -requiredVersion '1.0.0'`;
+            const tasks = parsePsakeFile(content);
+            assert.strictEqual(tasks[0].requiredVersion, '1.0.0');
+            assert.strictEqual(tasks[0].minimumVersion, undefined);
+        });
+
+        test('parses -Version as alias for -requiredVersion', () => {
+            const content = `Task Test -FromModule PowerShellBuild -Version '1.0.0'`;
+            const tasks = parsePsakeFile(content);
+            assert.strictEqual(tasks[0].requiredVersion, '1.0.0');
+        });
+
+        test('parses -maximumVersion', () => {
+            const content = `Task Test -FromModule PowerShellBuild -minimumVersion '0.5.0' -maximumVersion '1.0.0'`;
+            const tasks = parsePsakeFile(content);
+            assert.strictEqual(tasks[0].minimumVersion, '0.5.0');
+            assert.strictEqual(tasks[0].maximumVersion, '1.0.0');
+        });
+
+        test('parses -lessThanVersion', () => {
+            const content = `Task Test -FromModule PowerShellBuild -lessThanVersion '2.0.0'`;
+            const tasks = parsePsakeFile(content);
+            assert.strictEqual(tasks[0].lessThanVersion, '2.0.0');
+        });
+
+        test('parses -FromModule with double-quoted module name', () => {
+            const content = `Task Test -FromModule "PowerShellBuild" -minimumVersion "0.6.1"`;
+            const tasks = parsePsakeFile(content);
+            assert.strictEqual(tasks[0].fromModule, 'PowerShellBuild');
+            assert.strictEqual(tasks[0].minimumVersion, '0.6.1');
+        });
+
+        test('parses -FromModule on continuation lines', () => {
+            const content = [
+                'Task Test `',
+                '    -FromModule PowerShellBuild `',
+                "    -minimumVersion '0.6.1'",
+            ].join('\n');
+            const tasks = parsePsakeFile(content);
+            assert.strictEqual(tasks.length, 1);
+            assert.strictEqual(tasks[0].name, 'Test');
+            assert.strictEqual(tasks[0].fromModule, 'PowerShellBuild');
+            assert.strictEqual(tasks[0].minimumVersion, '0.6.1');
+        });
+
+        test('parses -FromModule task with local -Depends', () => {
+            // psake allows a reference task to declare additional local dependencies
+            const content = `Task Test -FromModule PowerShellBuild -Depends LocalSetup -minimumVersion '0.6.1'`;
+            const tasks = parsePsakeFile(content);
+            assert.strictEqual(tasks[0].fromModule, 'PowerShellBuild');
+            assert.deepStrictEqual(tasks[0].dependencies, ['LocalSetup']);
+            assert.strictEqual(tasks[0].minimumVersion, '0.6.1');
+        });
+
+        test('fromModule is undefined on normal tasks', () => {
+            const content = `Task Build -Depends Clean { }`;
+            const tasks = parsePsakeFile(content);
+            assert.strictEqual(tasks[0].fromModule, undefined);
+            assert.strictEqual(tasks[0].minimumVersion, undefined);
+        });
+    });
 });

--- a/src/treeView.ts
+++ b/src/treeView.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { findPsakeFiles, parsePsakeFile, PsakeTaskInfo } from './psakeParser.js';
+import { PsakeModuleResolver, enrichModuleTasks } from './moduleResolver.js';
 import { logError } from './log.js';
 
 // ---------------------------------------------------------------------------
@@ -43,21 +44,56 @@ export class PsakeTaskItem extends vscode.TreeItem {
         this.taskLine = info.line;
         this.contextValue = 'psakeTask';
 
-        this.description = info.description || (info.dependencies.length > 0
-            ? `depends: ${info.dependencies.join(', ')}`
-            : '');
+        // Description
+        if (info.fromModule) {
+            if (info.moduleResolved === false) {
+                this.description = `⚠ not found: ${info.fromModule}`;
+            } else {
+                const depsStr = info.dependencies.length > 0
+                    ? ` · depends: ${info.dependencies.join(', ')}`
+                    : '';
+                this.description = `from: ${info.fromModule}${depsStr}`;
+            }
+        } else {
+            this.description = info.description || (info.dependencies.length > 0
+                ? `depends: ${info.dependencies.join(', ')}`
+                : '');
+        }
 
-        this.tooltip = new vscode.MarkdownString(
-            [
-                `**${info.name}**`,
-                info.description ? `\n\n${info.description}` : '',
-                info.dependencies.length > 0 ? `\n\n*Depends on:* ${info.dependencies.join(', ')}` : '',
-            ].join('')
-        );
+        // Tooltip
+        const tooltipParts: string[] = [`**${info.name}**`];
+        if (info.description) {
+            tooltipParts.push(`\n\n${info.description}`);
+        }
+        if (info.fromModule) {
+            tooltipParts.push(`\n\n*From module:* \`${info.fromModule}\``);
+            const versionParts: string[] = [];
+            if (info.requiredVersion) { versionParts.push(`version ${info.requiredVersion}`); }
+            if (info.minimumVersion) { versionParts.push(`≥ ${info.minimumVersion}`); }
+            if (info.maximumVersion) { versionParts.push(`≤ ${info.maximumVersion}`); }
+            if (info.lessThanVersion) { versionParts.push(`< ${info.lessThanVersion}`); }
+            if (versionParts.length > 0) {
+                tooltipParts.push(` *(${versionParts.join(', ')})*`);
+            }
+            if (info.moduleResolved === false) {
+                tooltipParts.push(`\n\n⚠ *Module not found or version constraint not satisfied.*`);
+            }
+        }
+        if (info.dependencies.length > 0) {
+            tooltipParts.push(`\n\n*Depends on:* ${info.dependencies.join(', ')}`);
+        }
+        this.tooltip = new vscode.MarkdownString(tooltipParts.join(''));
 
-        this.iconPath = new vscode.ThemeIcon(
-            info.name.toLowerCase() === 'default' ? 'home' : 'play-circle'
-        );
+        // Icon
+        if (info.name.toLowerCase() === 'default') {
+            this.iconPath = new vscode.ThemeIcon('home');
+        } else if (info.fromModule) {
+            this.iconPath = new vscode.ThemeIcon(
+                info.moduleResolved === false ? 'warning' : 'package'
+            );
+        } else {
+            this.iconPath = new vscode.ThemeIcon('play-circle');
+        }
 
         // Clicking a task item opens the file at the task's line
         this.command = {
@@ -81,10 +117,12 @@ export class PsakeTreeDataProvider implements vscode.TreeDataProvider<PsakeTreeI
     /** Cached map of build file URI → parsed tasks */
     private cache = new Map<string, { uri: vscode.Uri; folder: vscode.WorkspaceFolder; tasks: PsakeTaskInfo[] }>();
     private loaded = false;
+    private readonly resolver: PsakeModuleResolver | undefined;
 
     private watcherDisposables: vscode.Disposable[] = [];
 
-    constructor(watcher: vscode.FileSystemWatcher) {
+    constructor(watcher: vscode.FileSystemWatcher, resolver?: PsakeModuleResolver) {
+        this.resolver = resolver;
         this.bindWatcher(watcher);
     }
 
@@ -151,6 +189,9 @@ export class PsakeTreeDataProvider implements vscode.TreeDataProvider<PsakeTreeI
                 const bytes = await vscode.workspace.fs.readFile(uri);
                 const content = Buffer.from(bytes).toString('utf8');
                 const tasks = parsePsakeFile(content);
+                if (this.resolver) {
+                    await enrichModuleTasks(tasks, this.resolver);
+                }
                 this.cache.set(uri.toString(), { uri, folder, tasks });
             } catch (err) {
                 logError(err, false);

--- a/src/treeView.ts
+++ b/src/treeView.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { findPsakeFiles, parsePsakeFile, PsakeTaskInfo } from './psakeParser.js';
-import { PsakeModuleResolver, enrichModuleTasks } from './moduleResolver.js';
+import { findPsakeFiles, PsakeTaskInfo } from './psakeParser.js';
+import { PsakeModuleResolver, resolveAllTasks } from './moduleResolver.js';
 import { logError } from './log.js';
 
 // ---------------------------------------------------------------------------
@@ -188,10 +188,7 @@ export class PsakeTreeDataProvider implements vscode.TreeDataProvider<PsakeTreeI
             try {
                 const bytes = await vscode.workspace.fs.readFile(uri);
                 const content = Buffer.from(bytes).toString('utf8');
-                const tasks = parsePsakeFile(content);
-                if (this.resolver) {
-                    await enrichModuleTasks(tasks, this.resolver);
-                }
+                const tasks = await resolveAllTasks(content, uri, this.resolver);
                 this.cache.set(uri.toString(), { uri, folder, tasks });
             } catch (err) {
                 logError(err, false);


### PR DESCRIPTION
### Added

- **Module task resolution (`-FromModule`)**: tasks can now reference other
  psake modules with version constraints (MinimumVersion, MaximumVersion,
  RequiredVersion, LessThanVersion). Module tasks are resolved to show
  dependencies and descriptions in the tree view and jump-to-definition
  navigates to the module's psakeFile.ps1
- **Include file support**: tasks from files included via `Include` statements
  (with `-Path`, `-LiteralPath`, or `-fileNamePathToInclude` parameters) are
  now discovered and displayed in the tree view, task provider, and code lens
- **Full task expansion**: all tasks exported by referenced modules become
  available to the build, appearing in task lists and completions
- **Source file tracking**: tasks from modules or include files retain their
  source file path for accurate navigation and visual distinction
- **New snippet**: `psakeTaskFromModule` for quickly authoring module reference
  tasks with version constraints

### Changed

- Parser now extracts `-FromModule` parameter and version constraints
- Tree view, task provider, and completions now show module and include task
  origins via icons and metadata
- Task definition interface now tracks module/include source and resolved state

### Fixed

- Version constraint comparison logic matches psake's Test-ModuleVersion
  semantics exactly (minimum ≥, maximum ≤, less-than <, required ==)