### PR TITLE
Support psake files in subdirectories with per-directory build script resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [1.2.0] 2026-04-06
+
+### Added
+
+- **Per-directory build script resolution**: each psakefile now uses a co-located
+  `build.ps1` if one exists in its directory, instead of always using the
+  workspace root's build script. Supports monorepo layouts where subdirectories
+  have their own `psakefile.ps1` + `build.ps1` pairs
+- Tasks now run with `cwd` set to the psakefile's directory, so relative paths
+  in build scripts resolve correctly
+
+### Changed
+
+- `psake.buildScript` explicit config is now resolved to an absolute path so it
+  works regardless of the task's working directory
+- Build script auto-detection searches the psakefile's directory instead of only
+  the workspace root
+
 ## [1.1.0] 2026-03-14
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "psake-vscode",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "psake-vscode",
-			"version": "1.1.0",
+			"version": "1.2.0",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -2144,7 +2144,7 @@
 			}
 		},
 		"node_modules/environment": {
-			"version": "1.1.0",
+			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
 			"integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
 			"dev": true,
@@ -2331,7 +2331,7 @@
 			}
 		},
 		"node_modules/fd-slicer": {
-			"version": "1.1.0",
+			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
 			"integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
 			"dev": true,
@@ -2668,7 +2668,7 @@
 			}
 		},
 		"node_modules/has-symbols": {
-			"version": "1.1.0",
+			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
 			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
 			"dev": true,
@@ -3366,7 +3366,7 @@
 			}
 		},
 		"node_modules/math-intrinsics": {
-			"version": "1.1.0",
+			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
 			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
 			"dev": true,
@@ -4401,7 +4401,7 @@
 			}
 		},
 		"node_modules/reusify": {
-			"version": "1.1.0",
+			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
 			"integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
 			"dev": true,
@@ -4562,7 +4562,7 @@
 			}
 		},
 		"node_modules/side-channel": {
-			"version": "1.1.0",
+			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
 			"integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
 			"dev": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "psake-vscode",
-	"version": "1.0.1",
+	"version": "1.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "psake-vscode",
-			"version": "1.0.1",
+			"version": "1.1.0",
 			"funding": [
 				{
 					"type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "psake",
 	"publisher": "psake",
 	"description": "Psake build script language support for Visual Studio Code.",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"icon": "images/psake.png",
 	"private": true,
 	"author": {

--- a/src/taskProvider.ts
+++ b/src/taskProvider.ts
@@ -18,7 +18,7 @@ export class PsakeTaskProvider implements vscode.TaskProvider {
     private cachedTasks: vscode.Task[] | undefined;
     private watcherDisposables: vscode.Disposable[] = [];
     private detectedExecutable: string | undefined;
-    /** Cached build script path per workspace folder URI */
+    /** Cached build script path per directory URI */
     private buildScriptCache = new Map<string, string | undefined>();
     private readonly resolver: PsakeModuleResolver | undefined;
 
@@ -73,8 +73,12 @@ export class PsakeTaskProvider implements vscode.TaskProvider {
         }
 
         const folder = scope as vscode.WorkspaceFolder;
-        const buildScript = await this.resolveBuildScript(folder);
-        return this.buildTask(def, folder, undefined, buildScript);
+        const defaultFile: string = vscode.workspace.getConfiguration('psake', folder).get('buildFile') ?? 'psakefile.ps1';
+        const relFile = def.file ?? defaultFile;
+        const psakeFileDir = path.resolve(folder.uri.fsPath, path.dirname(relFile));
+        const dirUri = vscode.Uri.file(psakeFileDir);
+        const buildScript = await this.resolveBuildScript(folder, dirUri);
+        return this.buildTask(def, folder, undefined, buildScript, psakeFileDir);
     }
 
     /**
@@ -85,8 +89,13 @@ export class PsakeTaskProvider implements vscode.TaskProvider {
         def: vscode.TaskDefinition,
         folder: vscode.WorkspaceFolder
     ): Promise<vscode.Task> {
-        const buildScript = await this.resolveBuildScript(folder);
-        return this.buildTask(def as PsakeTaskDefinition, folder, undefined, buildScript);
+        const pDef = def as PsakeTaskDefinition;
+        const defaultFile: string = vscode.workspace.getConfiguration('psake', folder).get('buildFile') ?? 'psakefile.ps1';
+        const relFile = pDef.file ?? defaultFile;
+        const psakeFileDir = path.resolve(folder.uri.fsPath, path.dirname(relFile));
+        const dirUri = vscode.Uri.file(psakeFileDir);
+        const buildScript = await this.resolveBuildScript(folder, dirUri);
+        return this.buildTask(pDef, folder, undefined, buildScript, psakeFileDir);
     }
 
     // -------------------------------------------------------------------------
@@ -114,10 +123,11 @@ export class PsakeTaskProvider implements vscode.TaskProvider {
      * Resolution order:
      * 1. `psake.buildScript` set to "none" → no build script
      * 2. `psake.buildScript` set to a path → use that path
-     * 3. `psake.buildScript` empty → auto-detect build.ps1 in workspace root
+     * 3. `psake.buildScript` empty → auto-detect build.ps1 in psakefile directory
      */
-    private async resolveBuildScript(folder: vscode.WorkspaceFolder): Promise<string | undefined> {
-        const key = folder.uri.toString();
+    private async resolveBuildScript(folder: vscode.WorkspaceFolder, dirUri?: vscode.Uri): Promise<string | undefined> {
+        const searchUri = dirUri ?? folder.uri;
+        const key = searchUri.toString();
         if (this.buildScriptCache.has(key)) {
             return this.buildScriptCache.get(key);
         }
@@ -130,11 +140,11 @@ export class PsakeTaskProvider implements vscode.TaskProvider {
         if (configured.toLowerCase() === 'none') {
             result = undefined;
         } else if (configured) {
-            result = configured;
+            result = path.resolve(folder.uri.fsPath, configured);
         } else {
-            // Auto-detect build.ps1 in workspace root (case-insensitive)
+            // Auto-detect build.ps1 in the psakefile's directory (case-insensitive)
             try {
-                const files = await vscode.workspace.fs.readDirectory(folder.uri);
+                const files = await vscode.workspace.fs.readDirectory(searchUri);
                 const buildFile = files.find(([name, type]) =>
                     type === vscode.FileType.File &&
                     name.toLowerCase() === 'build.ps1'
@@ -161,7 +171,7 @@ export class PsakeTaskProvider implements vscode.TaskProvider {
         const uris = await findPsakeFiles();
         const tasks: vscode.Task[] = [];
 
-        // Group URIs by workspace folder so we resolve the build script once per folder
+        // Group URIs by workspace folder
         const folderMap = new Map<string, { folder: vscode.WorkspaceFolder; uris: vscode.Uri[] }>();
         for (const uri of uris) {
             const folder = vscode.workspace.getWorkspaceFolder(uri);
@@ -176,9 +186,11 @@ export class PsakeTaskProvider implements vscode.TaskProvider {
         }
 
         for (const { folder, uris: folderUris } of folderMap.values()) {
-            const buildScript = await this.resolveBuildScript(folder);
-
             for (const uri of folderUris) {
+                const psakeFileDir = path.dirname(uri.fsPath);
+                const dirUri = vscode.Uri.file(psakeFileDir);
+                const buildScript = await this.resolveBuildScript(folder, dirUri);
+
                 try {
                     const bytes = await vscode.workspace.fs.readFile(uri);
                     const content = Buffer.from(bytes).toString('utf8');
@@ -191,7 +203,7 @@ export class PsakeTaskProvider implements vscode.TaskProvider {
                             task: info.name,
                             file: relativeFile,
                         };
-                        tasks.push(this.buildTask(def, folder, info.description, buildScript));
+                        tasks.push(this.buildTask(def, folder, info.description, buildScript, psakeFileDir));
                     }
                 } catch (err) {
                     logError(err, false);
@@ -206,17 +218,20 @@ export class PsakeTaskProvider implements vscode.TaskProvider {
         def: PsakeTaskDefinition,
         folder: vscode.WorkspaceFolder,
         description?: string,
-        buildScript?: string
+        buildScript?: string,
+        psakeFileDir?: string
     ): vscode.Task {
         const config = vscode.workspace.getConfiguration('psake', folder);
         const defaultFile: string = config.get('buildFile') ?? 'psakefile.ps1';
         const buildFile = def.file ?? defaultFile;
+        // When cwd is set to the psakefile's directory, use just the filename
+        const invokeFile = psakeFileDir ? path.basename(buildFile) : buildFile;
 
         const extraInvokeParams: string = config.get('invokeParameters') ?? '';
         const extraScriptParams: string = config.get('buildScriptParameters') ?? '';
         const command = buildScript
             ? buildBuildScriptCommand(buildScript, def.task, config.get('buildScriptTaskParameter') ?? 'Task', extraScriptParams)
-            : buildInvokePsakeCommand(buildFile, def.task, extraInvokeParams);
+            : buildInvokePsakeCommand(invokeFile, def.task, extraInvokeParams);
 
         // Use the already-detected executable; fall back to pwsh if not yet detected.
         const executable = this.detectedExecutable ?? 'pwsh';
@@ -230,6 +245,7 @@ export class PsakeTaskProvider implements vscode.TaskProvider {
             new vscode.ShellExecution(command, {
                 executable,
                 shellArgs: [...extraShellArgs, '-Command'],
+                cwd: psakeFileDir,
             }),
             []
         );
@@ -256,5 +272,6 @@ function buildBuildScriptCommand(scriptPath: string, taskName: string, parameter
     const escapedTask = taskName.replace(/'/g, "''");
     const escapedParam = parameterName.replace(/^-/, '');
     const extra = extraParams ? ` ${extraParams}` : '';
-    return `./'${escapedScript}' -${escapedParam} '${escapedTask}'${extra}`;
+    const prefix = path.isAbsolute(scriptPath) ? `& '${escapedScript}'` : `./'${escapedScript}'`;
+    return `${prefix} -${escapedParam} '${escapedTask}'${extra}`;
 }


### PR DESCRIPTION
## Summary
This change enhances the psake task provider to properly support psake files located in subdirectories of the workspace. Previously, the build script resolution and task execution were always relative to the workspace root. Now, each psake file can have its own build script resolution and execution context based on its directory location.

## Key Changes
- **Per-directory build script resolution**: Modified `resolveBuildScript()` to accept an optional `dirUri` parameter, allowing build script auto-detection to occur in the psakefile's directory rather than always in the workspace root
- **Updated task resolution**: Both `resolveTask()` and `provideTask()` now calculate the psakefile directory and pass it to build script resolution
- **Working directory support**: Added `cwd` (current working directory) parameter to shell execution, set to the psakefile's directory when available
- **Relative path handling**: When a working directory is set, task invocation uses just the filename instead of the full relative path
- **Absolute path support**: Enhanced `buildBuildScriptCommand()` to handle both absolute and relative build script paths, using `& '...'` syntax for absolute paths
- **Configuration resolution**: Build file configuration is now resolved relative to the workspace folder before calculating the psakefile directory

## Implementation Details
- The cache key for build scripts now uses the directory URI instead of workspace folder URI, enabling independent caching per psakefile location
- Task discovery now resolves the build script for each individual psakefile rather than once per workspace folder
- Comments updated to reflect that build script auto-detection now searches the psakefile's directory instead of the workspace root

https://claude.ai/code/session_01HzmshrBREzqjofW1nit3wZ