### PR TITLE
Add $psake and $psake-powershell problem matchers for VS Code tasks

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -82,7 +82,7 @@ jobs:
         run: node esbuild.mjs --production
 
       - name: Package VSIX
-        run: npx @vscode/vsce package --out ./out/
+        run: npx @vscode/vsce package --out out
 
       - name: Upload VSIX artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/CreateRelease.yaml
+++ b/.github/workflows/CreateRelease.yaml
@@ -30,10 +30,21 @@ jobs:
       - name: Type check
         run: npx tsc --noEmit
 
+      - name: Read and validate changelog
+        id: changelog
+        uses: mindsers/changelog-reader-action@v2
+        with:
+          validation_level: warn
+          path: ./CHANGELOG.md
+
       - name: Package VSIX
         run: |
           mkdir -p out
-          npx @vscode/vsce package --out ./out/
+          if [ "${{ steps.changelog.outputs.status }}" = "prereleased" ]; then
+            npx @vscode/vsce package --pre-release --out ./out/
+          else
+            npx @vscode/vsce package --out ./out/
+          fi
 
       - name: Extract release metadata
         id: release_meta
@@ -63,12 +74,7 @@ jobs:
           Get-ChildItem -Path ./out/*.vsix | ForEach-Object {
               echo "asset_path=$($_.FullName)" >> $env:GITHUB_OUTPUT
           }
-      - name: Read and validate changelog (keepachangelog)
-        id: changelog
-        uses: mindsers/changelog-reader-action@v2
-        with:
-          validation_level: warn
-          path: ./CHANGELOG.md
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -85,3 +91,4 @@ jobs:
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
           extensionFile: ${{ steps.release_meta.outputs.asset_path }}
           registryUrl: https://marketplace.visualstudio.com
+          preRelease: ${{ steps.changelog.outputs.status == 'prereleased' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## [1.3.0-preview.1] 2026-04-10
+
+### Added
+
+- **Problem matchers for psake v5**: two new named problem matchers surface
+  errors and warnings in the VS Code Problems panel with clickable
+  file/line/column navigation
+  - `$psake`: parses GitHub Actions-compatible annotation lines emitted by
+    psake v5's `Annotated` output format
+  - `$psake-powershell`: fallback matcher for raw PowerShell error output
+    (e.g. syntax errors before the build plan compiles)
+- **Automatic activation**: the task provider auto-attaches both matchers and
+  sets `PSAKE_OUTPUT_FORMAT=Annotated` in the shell environment so the mode
+  works through wrapper scripts without parameter forwarding
+- **New setting** `psake.problemMatcher.enabled` (default: `true`): controls
+  problem matcher attachment and environment variable injection. Set to `false`
+  to disable without affecting the rest of the task provider
+- The "Sync Tasks" command now includes `problemMatcher` on newly created
+  `tasks.json` entries
+
+### Notes
+
+- Requires psake v5 (alpha) with `Annotated` output format support for the
+  `$psake` matcher to produce results. The `$psake-powershell` matcher works
+  independently
+- This is a preview release for early feedback — the problem matcher regexes
+  may be refined based on real-world psake v5 output samples
+
 ## [1.2.0] 2026-04-06
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -280,13 +280,17 @@
 	],
 	"cspell": {
 		"version": "0.2",
-		"ignorePaths": [],
+		"ignorePaths": [
+			".github/**",
+			"dist/**"
+		],
 		"dictionaryDefinitions": [],
 		"dictionaries": [],
 		"words": [
 			"opencollective",
 			"psake",
 			"psakefile",
+			"psakefiles",
 			"pwsh"
 		],
 		"ignoreWords": [],

--- a/package.json
+++ b/package.json
@@ -287,6 +287,7 @@
 		"dictionaryDefinitions": [],
 		"dictionaries": [],
 		"words": [
+			"nologo",
 			"opencollective",
 			"psake",
 			"psakefile",

--- a/package.json
+++ b/package.json
@@ -94,13 +94,22 @@
 		"problemPatterns": [
 			{
 				"name": "psake-annotation",
-				"regexp": "^::(error|warning|notice)\\s+file=([^,]+),line=(\\d+)(?:,endLine=\\d+)?(?:,col=(\\d+))?(?:,endColumn=\\d+)?(?:,title=(.*?))?::(.*)$",
+				"regexp": "^::(error|warning|info)\\s+file=([^,]+),line=(\\d+)(?:,endLine=\\d+)?(?:,col=(\\d+))?(?:,endColumn=\\d+)?(?:,title=(.*?))?::(.*)$",
 				"severity": 1,
 				"file": 2,
 				"line": 3,
 				"column": 4,
 				"code": 5,
 				"message": 6
+			},
+			{
+				"name": "psake-notice-annotation",
+				"regexp": "^::notice\\s+file=([^,]+),line=(\\d+)(?:,endLine=\\d+)?(?:,col=(\\d+))?(?:,endColumn=\\d+)?(?:,title=(.*?))?::(.*)$",
+				"file": 1,
+				"line": 2,
+				"column": 3,
+				"code": 4,
+				"message": 5
 			}
 		],
 		"problemMatchers": [
@@ -114,6 +123,18 @@
 					"${workspaceFolder}"
 				],
 				"pattern": "$psake-annotation"
+			},
+			{
+				"name": "psake-notice",
+				"owner": "psake",
+				"source": "psake",
+				"severity": "info",
+				"applyTo": "allDocuments",
+				"fileLocation": [
+					"autoDetect",
+					"${workspaceFolder}"
+				],
+				"pattern": "$psake-notice-annotation"
 			},
 			{
 				"name": "psake-powershell",

--- a/package.json
+++ b/package.json
@@ -277,5 +277,19 @@
 		"powershell",
 		"vscode",
 		"tasks"
-	]
+	],
+	"cspell": {
+		"version": "0.2",
+		"ignorePaths": [],
+		"dictionaryDefinitions": [],
+		"dictionaries": [],
+		"words": [
+			"opencollective",
+			"psake",
+			"psakefile",
+			"pwsh"
+		],
+		"ignoreWords": [],
+		"import": []
+	}
 }

--- a/package.json
+++ b/package.json
@@ -101,15 +101,6 @@
 				"column": 4,
 				"code": 5,
 				"message": 6
-			},
-			{
-				"name": "psake-notice-annotation",
-				"regexp": "^::notice\\s+file=([^,]+),line=(\\d+)(?:,endLine=\\d+)?(?:,col=(\\d+))?(?:,endColumn=\\d+)?(?:,title=(.*?))?::(.*)$",
-				"file": 1,
-				"line": 2,
-				"column": 3,
-				"code": 4,
-				"message": 5
 			}
 		],
 		"problemMatchers": [
@@ -125,18 +116,6 @@
 				"pattern": "$psake-annotation"
 			},
 			{
-				"name": "psake-notice",
-				"owner": "psake",
-				"source": "psake",
-				"severity": "info",
-				"applyTo": "allDocuments",
-				"fileLocation": [
-					"autoDetect",
-					"${workspaceFolder}"
-				],
-				"pattern": "$psake-notice-annotation"
-			},
-			{
 				"name": "psake-powershell",
 				"owner": "psake",
 				"source": "powershell",
@@ -148,7 +127,7 @@
 				],
 				"pattern": [
 					{
-						"regexp": "^(.+?)\\s*:\\s*(.+)$",
+						"regexp": "^(.+)\\s*:\\s*(.+)$",
 						"file": 1,
 						"message": 2
 					},

--- a/package.json
+++ b/package.json
@@ -91,6 +91,55 @@
 				}
 			}
 		],
+		"problemPatterns": [
+			{
+				"name": "psake-annotation",
+				"regexp": "^::(error|warning|notice)\\s+file=([^,]+),line=(\\d+)(?:,endLine=\\d+)?(?:,col=(\\d+))?(?:,endColumn=\\d+)?(?:,title=(.*?))?::(.*)$",
+				"severity": 1,
+				"file": 2,
+				"line": 3,
+				"column": 4,
+				"code": 5,
+				"message": 6
+			}
+		],
+		"problemMatchers": [
+			{
+				"name": "psake",
+				"owner": "psake",
+				"source": "psake",
+				"applyTo": "allDocuments",
+				"fileLocation": [
+					"autoDetect",
+					"${workspaceFolder}"
+				],
+				"pattern": "$psake-annotation"
+			},
+			{
+				"name": "psake-powershell",
+				"owner": "psake",
+				"source": "powershell",
+				"severity": "error",
+				"applyTo": "allDocuments",
+				"fileLocation": [
+					"autoDetect",
+					"${workspaceFolder}"
+				],
+				"pattern": [
+					{
+						"regexp": "^(.+?)\\s*:\\s*(.+)$",
+						"file": 1,
+						"message": 2
+					},
+					{
+						"regexp": "^At (?:(.+):)?(?:line:)?(\\d+) char:(\\d+)",
+						"file": 1,
+						"line": 2,
+						"column": 3
+					}
+				]
+			}
+		],
 		"views": {
 			"explorer": [
 				{
@@ -184,6 +233,11 @@
 					"type": "string",
 					"default": "",
 					"description": "Extra parameters appended to the build script call when a build script wrapper is used (e.g., \"-Configuration Release -Clean\")."
+				},
+				"psake.problemMatcher.enabled": {
+					"type": "boolean",
+					"default": true,
+					"description": "Attach $psake and $psake-powershell problem matchers to provider-created tasks and set PSAKE_OUTPUT_FORMAT=Annotated on invoked psake processes. Requires psake v5 with Annotated output format support."
 				}
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "psake",
 	"publisher": "psake",
 	"description": "Psake build script language support for Visual Studio Code.",
-	"version": "1.2.0",
+	"version": "1.3.0-preview.1",
 	"icon": "images/psake.png",
 	"private": true,
 	"author": {

--- a/src/syncTasksCommand.ts
+++ b/src/syncTasksCommand.ts
@@ -115,6 +115,7 @@ export async function syncTasksCommand(): Promise<void> {
             task: dt.name,
             file: dt.file,
             label: `psake: ${dt.name}`,
+            problemMatcher: ['$psake', '$psake-powershell'],
         };
 
         tasksJson.tasks.push(entry);

--- a/src/syncTasksCommand.ts
+++ b/src/syncTasksCommand.ts
@@ -115,7 +115,7 @@ export async function syncTasksCommand(): Promise<void> {
             task: dt.name,
             file: dt.file,
             label: `psake: ${dt.name}`,
-            problemMatcher: ['$psake', '$psake-powershell'],
+            problemMatcher: ['$psake', '$psake-notice', '$psake-powershell'],
         };
 
         tasksJson.tasks.push(entry);

--- a/src/syncTasksCommand.ts
+++ b/src/syncTasksCommand.ts
@@ -103,6 +103,8 @@ export async function syncTasksCommand(): Promise<void> {
     }
 
     // Add new tasks
+    const config = vscode.workspace.getConfiguration('psake', folder);
+    const problemMatcherEnabled: boolean = config.get('problemMatcher.enabled') ?? true;
     let added = 0;
     for (const dt of discoveredTasks) {
         const key = taskKey(dt.name, dt.file);
@@ -115,7 +117,7 @@ export async function syncTasksCommand(): Promise<void> {
             task: dt.name,
             file: dt.file,
             label: `psake: ${dt.name}`,
-            problemMatcher: ['$psake', '$psake-notice', '$psake-powershell'],
+            ...(problemMatcherEnabled && { problemMatcher: ['$psake', '$psake-powershell'] }),
         };
 
         tasksJson.tasks.push(entry);

--- a/src/taskProvider.ts
+++ b/src/taskProvider.ts
@@ -255,7 +255,7 @@ export class PsakeTaskProvider implements vscode.TaskProvider {
             def.task,
             'psake',
             new vscode.ShellExecution(command, shellOptions),
-            problemMatcherEnabled ? ['$psake', '$psake-powershell'] : []
+            problemMatcherEnabled ? ['$psake', '$psake-notice', '$psake-powershell'] : []
         );
 
         task.detail = description || `Run psake task '${def.task}'`;

--- a/src/taskProvider.ts
+++ b/src/taskProvider.ts
@@ -237,17 +237,25 @@ export class PsakeTaskProvider implements vscode.TaskProvider {
         const executable = this.detectedExecutable ?? 'pwsh';
         const extraShellArgs: string[] = config.get('shellArgs') ?? ['-NoProfile'];
 
+        const problemMatcherEnabled: boolean = config.get('problemMatcher.enabled') ?? true;
+
+        const shellOptions: vscode.ShellExecutionOptions = {
+            executable,
+            shellArgs: [...extraShellArgs, '-Command'],
+            cwd: psakeFileDir,
+        };
+
+        if (problemMatcherEnabled) {
+            shellOptions.env = { PSAKE_OUTPUT_FORMAT: 'Annotated' };
+        }
+
         const task = new vscode.Task(
             def,
             folder,
             def.task,
             'psake',
-            new vscode.ShellExecution(command, {
-                executable,
-                shellArgs: [...extraShellArgs, '-Command'],
-                cwd: psakeFileDir,
-            }),
-            []
+            new vscode.ShellExecution(command, shellOptions),
+            problemMatcherEnabled ? ['$psake', '$psake-powershell'] : []
         );
 
         task.detail = description || `Run psake task '${def.task}'`;

--- a/src/taskProvider.ts
+++ b/src/taskProvider.ts
@@ -255,7 +255,7 @@ export class PsakeTaskProvider implements vscode.TaskProvider {
             def.task,
             'psake',
             new vscode.ShellExecution(command, shellOptions),
-            problemMatcherEnabled ? ['$psake', '$psake-notice', '$psake-powershell'] : []
+            problemMatcherEnabled ? ['$psake', '$psake-powershell'] : []
         );
 
         task.detail = description || `Run psake task '${def.task}'`;


### PR DESCRIPTION
Contribute two named problem matchers that parse psake v5 output and
surface errors/warnings in the VS Code Problems panel:

- $psake: parses GitHub Actions-compatible annotation lines
  (::error file=...,line=...,col=...,title=...::message) emitted by
  psake v5's new Annotated output format
- $psake-powershell: fallback two-line matcher for raw PowerShell errors
  that bypass psake's structured output (e.g. parser errors)

The task provider auto-attaches both matchers and sets
PSAKE_OUTPUT_FORMAT=Annotated in the shell environment so the mode
activates through wrapper scripts without parameter forwarding.

A new psake.problemMatcher.enabled setting (default: true) controls
both the env var injection and matcher attachment.

https://claude.ai/code/session_01R6yV6B1aDTy9DHcRvXkRpa