### PR TITLE
Use absolute paths for psake build file invocation

### DIFF
--- a/src/taskProvider.ts
+++ b/src/taskProvider.ts
@@ -224,8 +224,8 @@ export class PsakeTaskProvider implements vscode.TaskProvider {
         const config = vscode.workspace.getConfiguration('psake', folder);
         const defaultFile: string = config.get('buildFile') ?? 'psakefile.ps1';
         const buildFile = def.file ?? defaultFile;
-        // When cwd is set to the psakefile's directory, use just the filename
-        const invokeFile = psakeFileDir ? path.basename(buildFile) : buildFile;
+        // Always resolve to an absolute path so the command works regardless of cwd
+        const invokeFile = path.resolve(folder.uri.fsPath, buildFile);
 
         const extraInvokeParams: string = config.get('invokeParameters') ?? '';
         const extraScriptParams: string = config.get('buildScriptParameters') ?? '';


### PR DESCRIPTION
## Summary
Changed the psake task provider to always resolve build file paths to absolute paths instead of conditionally using relative filenames based on the working directory.

## Key Changes
- Modified `invokeFile` resolution to use `path.resolve()` with the workspace folder path and build file, ensuring an absolute path is always used
- This change makes the command execution independent of the current working directory setting
- Updated the comment to reflect that absolute paths are now always used

## Implementation Details
The previous implementation conditionally used either a relative filename (when `psakeFileDir` was set) or the full build file path. The new approach consistently resolves to an absolute path by combining the workspace folder URI path with the configured build file path, making the behavior more predictable and robust regardless of how the working directory is configured.

https://claude.ai/code/session_01E18ruuY1XXHKmQQWgNnUJU