### PR TITLE
Release 1.4.0 and switch pre-release to a workflow input

### DIFF
--- a/.github/workflows/CreateRelease.yaml
+++ b/.github/workflows/CreateRelease.yaml
@@ -2,6 +2,11 @@ name: Create Release
 
 on:
   workflow_dispatch:
+    inputs:
+      pre_release:
+        description: "Publish as a pre-release (VS Code Marketplace --pre-release + GitHub prerelease)"
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -30,23 +35,7 @@ jobs:
       - name: Type check
         run: npx tsc --noEmit
 
-      - name: Read and validate changelog
-        id: changelog
-        uses: mindsers/changelog-reader-action@v2
-        with:
-          validation_level: warn
-          path: ./CHANGELOG.md
-
-      - name: Package VSIX
-        run: |
-          mkdir -p out
-          if [ "${{ steps.changelog.outputs.status }}" = "prereleased" ]; then
-            npx @vscode/vsce package --pre-release --out ./out/
-          else
-            npx @vscode/vsce package --out ./out/
-          fi
-
-      - name: Extract release metadata
+      - name: Resolve release metadata
         id: release_meta
         shell: pwsh
         run: |
@@ -56,21 +45,39 @@ jobs:
           echo "version=$version" >> $env:GITHUB_OUTPUT
           echo "tag=v$version" >> $env:GITHUB_OUTPUT
 
-          # Extract latest changelog entry
+          # VS Code Marketplace requires bare major.minor.patch (no -suffix) for pre-releases.
+          # See https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions
+          if ($version -notmatch '^\d+\.\d+\.\d+$') {
+              throw "package.json version '$version' must be major.minor.patch with no suffix."
+          }
+
+          # Extract latest changelog entry body for the GitHub Release
           $changelog = Get-Content CHANGELOG.md -Raw
-          # Match the first ## [x.y.z] section and grab its body
-          if ($changelog -match '(?ms)^## \[([^\]]+)\]\s*\r?\n(.*?)(?=^## |\z)') {
+          if ($changelog -match '(?ms)^## \[([^\]]+)\][^\n]*\r?\n(.*?)(?=^## |\z)') {
               $title = $Matches[1]
               $body = $Matches[2].Trim()
+              if ($title -ne $version) {
+                  throw "Top changelog entry is [$title] but package.json is $version — they must match before releasing."
+              }
               echo "title=$title" >> $env:GITHUB_OUTPUT
-
-              # Write body to a file for multi-line output
               $body | Out-File -FilePath release_body.md -Encoding utf8
           } else {
-              echo "title=v$version" >> $env:GITHUB_OUTPUT
-              "Release v$version" | Out-File -FilePath release_body.md -Encoding utf8
+              throw "No ## [x.y.z] section found in CHANGELOG.md."
           }
-          # Output the file path for later steps
+
+      - name: Package VSIX
+        run: |
+          mkdir -p out
+          if [ "${{ inputs.pre_release }}" = "true" ]; then
+            npx @vscode/vsce package --pre-release --out ./out/
+          else
+            npx @vscode/vsce package --out ./out/
+          fi
+
+      - name: Record VSIX path
+        id: vsix
+        shell: pwsh
+        run: |
           Get-ChildItem -Path ./out/*.vsix | ForEach-Object {
               echo "asset_path=$($_.FullName)" >> $env:GITHUB_OUTPUT
           }
@@ -79,16 +86,15 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.release_meta.outputs.tag }}
-          name: Release ${{ steps.changelog.outputs.version }}
-          body: ${{ steps.changelog.outputs.changes }}
-          prerelease: ${{ steps.changelog.outputs.status == 'prereleased' }}
-          draft: ${{ steps.changelog.outputs.status == 'unreleased' }}
-          files: ${{ steps.release_meta.outputs.asset_path }}
+          name: Release ${{ steps.release_meta.outputs.version }}
+          body_path: release_body.md
+          prerelease: ${{ inputs.pre_release }}
+          files: ${{ steps.vsix.outputs.asset_path }}
 
       - name: Publish to VS Code Marketplace
         uses: HaaLeo/publish-vscode-extension@v2
         with:
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
-          extensionFile: ${{ steps.release_meta.outputs.asset_path }}
+          extensionFile: ${{ steps.vsix.outputs.asset_path }}
           registryUrl: https://marketplace.visualstudio.com
-          preRelease: ${{ steps.changelog.outputs.status == 'prereleased' }}
+          preRelease: ${{ inputs.pre_release }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.3.0-preview.1] 2026-04-10
+## [1.4.0] 2026-04-12
 
 ### Added
 
@@ -25,8 +25,6 @@
 - Requires psake v5 (alpha) with `Annotated` output format support for the
   `$psake` matcher to produce results. The `$psake-powershell` matcher works
   independently
-- This is a preview release for early feedback — the problem matcher regexes
-  may be refined based on real-world psake v5 output samples
 
 ## [1.2.0] 2026-04-06
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "psake",
 	"publisher": "psake",
 	"description": "Psake build script language support for Visual Studio Code.",
-	"version": "1.3.0-preview.1",
+	"version": "1.4.0",
 	"icon": "images/psake.png",
 	"private": true,
 	"author": {


### PR DESCRIPTION
## Summary
- Bumps `1.3.0-preview.1` → `1.4.0` in `package.json` and `CHANGELOG.md` so the VS Code Marketplace accepts the package (marketplace requires bare `major.minor.patch`, no `-preview` suffix — see https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions).
- Replaces the `mindsers/changelog-reader-action` "prereleased" heuristic in `CreateRelease.yaml` with an explicit `workflow_dispatch` boolean input (`pre_release`, default `false`) that drives `vsce package --pre-release`, the GitHub Release `prerelease` flag, and the Marketplace `preRelease` flag.
- Adds a version format guard and a changelog/version match check so releases fail fast when the two drift.

## Test plan
- [ ] Dispatch `Create Release` with `pre_release = false` → publishes `1.4.0` as a stable release on GitHub and the Marketplace.
- [ ] Future dispatch with `pre_release = true` on a version like `1.5.0` → VSIX packaged with `--pre-release`, GitHub release marked prerelease, Marketplace listing marked pre-release.
- [ ] Version/changelog mismatch (e.g. bump `package.json` without updating `CHANGELOG.md`) → workflow fails at the `Resolve release metadata` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)