### PR TITLE
chore(release): 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [Unreleased]
+
+## [1.5.0] - 2026-04-12
+
+### Added
+
+- **Build/Test classification for psake tasks**: auto-detected tasks whose
+  names match patterns like `test`/`pester`/`spec` are placed in the Test
+  group and get the `$pester` problem matcher appended; names matching
+  `build`/`compile`/`publish`/`package`/`release`/`dist` are placed in the
+  Build group. This makes "Run Test Task" and "Run Build Task" work without
+  any configuration
+- The "Sync Tasks" command uses the same classifier to pre-select tasks and
+  prompts for confirmation before writing `tasks.json`, so persisted entries
+  reflect user intent rather than pure heuristic
+- New setting `psake.classifyByName` (default: `true`) controls both
+  behaviors. Disable to skip classification entirely
+
+### Changed
+
+- Gallery banner color updated to `#1c1e21` for better contrast on the
+  Marketplace listing
+
 ## [1.4.0] 2026-04-12
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "psake",
 	"publisher": "psake",
 	"description": "Psake build script language support for Visual Studio Code.",
-	"version": "1.4.0",
+	"version": "1.5.0",
 	"icon": "images/psake.png",
 	"private": true,
 	"author": {
@@ -19,7 +19,7 @@
 		"url": "https://github.com/psake/psake-vscode"
 	},
 	"galleryBanner": {
-		"color": "#7E7E7C",
+		"color": "#1c1e21",
 		"theme": "dark"
 	},
 	"engines": {
@@ -238,6 +238,11 @@
 					"type": "boolean",
 					"default": true,
 					"description": "Attach $psake and $psake-powershell problem matchers to provider-created tasks and set PSAKE_OUTPUT_FORMAT=Annotated on invoked psake processes. Requires psake v5 with Annotated output format support."
+				},
+				"psake.classifyByName": {
+					"type": "boolean",
+					"default": true,
+					"description": "Heuristically classify psake tasks as Build or Test based on their names. Test tasks are placed in the Test group and get the $pester problem matcher appended; Build tasks go to the Build group. Applies to auto-detected tasks and to the Sync Tasks prompt (which also asks for confirmation). Disable to skip classification entirely."
 				}
 			}
 		}

--- a/src/syncTasksCommand.ts
+++ b/src/syncTasksCommand.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { findPsakeFiles, parsePsakeFile } from './psakeParser.js';
 import { TASK_TYPE } from './constants.js';
 import { logError } from './log.js';
+import { classifyByName, TaskClass } from './taskClassifier.js';
 
 interface TasksJsonContent {
     version: string;
@@ -15,6 +16,8 @@ interface TaskEntry {
     task?: string;
     label?: string;
     file?: string;
+    group?: string | { kind: string; isDefault?: boolean };
+    problemMatcher?: string | string[];
     [key: string]: unknown;
 }
 
@@ -102,31 +105,53 @@ export async function syncTasksCommand(): Promise<void> {
         }
     }
 
-    // Add new tasks
+    // Filter to tasks that will actually be added (new ones)
+    const newTasks = discoveredTasks.filter(dt => !existingPsakeKeys.has(taskKey(dt.name, dt.file)));
+
+    if (newTasks.length === 0) {
+        void vscode.window.showInformationMessage('tasks.json is already up to date with all psake tasks.');
+        return;
+    }
+
+    // Classify new tasks by name, then let the user confirm/adjust.
     const config = vscode.workspace.getConfiguration('psake', folder);
     const problemMatcherEnabled: boolean = config.get('problemMatcher.enabled') ?? true;
-    let added = 0;
-    for (const dt of discoveredTasks) {
-        const key = taskKey(dt.name, dt.file);
-        if (existingPsakeKeys.has(key)) {
-            continue;
+    const classifyEnabled: boolean = config.get('classifyByName') ?? true;
+
+    const classifications = new Map<string, TaskClass>();
+    for (const dt of newTasks) {
+        classifications.set(taskKey(dt.name, dt.file), classifyEnabled ? classifyByName(dt.name) : 'none');
+    }
+
+    if (classifyEnabled) {
+        const adjusted = await promptClassifications(newTasks, classifications);
+        if (!adjusted) {
+            // User cancelled
+            return;
         }
+    }
+
+    // Add new tasks
+    let added = 0;
+    for (const dt of newTasks) {
+        const cls = classifications.get(taskKey(dt.name, dt.file)) ?? 'none';
+        const matchers = problemMatcherEnabled
+            ? (cls === 'test'
+                ? ['$psake', '$psake-powershell', '$pester']
+                : ['$psake', '$psake-powershell'])
+            : undefined;
 
         const entry: TaskEntry = {
             type: TASK_TYPE,
             task: dt.name,
             file: dt.file,
             label: `psake: ${dt.name}`,
-            ...(problemMatcherEnabled && { problemMatcher: ['$psake', '$psake-powershell'] }),
+            ...(cls !== 'none' && { group: cls }),
+            ...(matchers && { problemMatcher: matchers }),
         };
 
         tasksJson.tasks.push(entry);
         added++;
-    }
-
-    if (added === 0) {
-        void vscode.window.showInformationMessage('tasks.json is already up to date with all psake tasks.');
-        return;
     }
 
     // Ensure .vscode directory exists
@@ -151,4 +176,72 @@ export async function syncTasksCommand(): Promise<void> {
 
 function taskKey(name: string, file?: string): string {
     return `${(file ?? '').toLowerCase()}::${name.toLowerCase()}`;
+}
+
+interface DiscoveredTask {
+    name: string;
+    file: string;
+    description: string;
+}
+
+/**
+ * Shows two sequential multi-select prompts (test, then build) to let the user
+ * confirm or override the heuristic classification. Mutates the supplied
+ * classifications map. Returns false if the user cancelled either prompt.
+ */
+async function promptClassifications(
+    tasks: DiscoveredTask[],
+    classifications: Map<string, TaskClass>
+): Promise<boolean> {
+    interface Item extends vscode.QuickPickItem {
+        key: string;
+    }
+
+    const items: Item[] = tasks.map(dt => ({
+        key: taskKey(dt.name, dt.file),
+        label: dt.name,
+        description: dt.file,
+        detail: dt.description || undefined,
+    }));
+
+    // Test pass: pre-select heuristic-test tasks
+    const testPicks = await vscode.window.showQuickPick(
+        items.map(it => ({ ...it, picked: classifications.get(it.key) === 'test' })),
+        {
+            canPickMany: true,
+            title: 'psake: Sync Tasks (1/2) — which tasks are Test tasks?',
+            placeHolder: 'Selected tasks will get group="test" and the $pester problem matcher. Press Enter to confirm.',
+        }
+    );
+    if (!testPicks) {
+        return false;
+    }
+    const testKeys = new Set(testPicks.map(p => p.key));
+
+    // Build pass: pre-select heuristic-build tasks, excluding any marked as test
+    const buildCandidates = items.filter(it => !testKeys.has(it.key));
+    const buildPicks = await vscode.window.showQuickPick(
+        buildCandidates.map(it => ({ ...it, picked: classifications.get(it.key) === 'build' })),
+        {
+            canPickMany: true,
+            title: 'psake: Sync Tasks (2/2) — which tasks are Build tasks?',
+            placeHolder: 'Selected tasks will get group="build". Press Enter to confirm.',
+        }
+    );
+    if (!buildPicks) {
+        return false;
+    }
+    const buildKeys = new Set(buildPicks.map(p => p.key));
+
+    // Apply user choices
+    for (const it of items) {
+        if (testKeys.has(it.key)) {
+            classifications.set(it.key, 'test');
+        } else if (buildKeys.has(it.key)) {
+            classifications.set(it.key, 'build');
+        } else {
+            classifications.set(it.key, 'none');
+        }
+    }
+    return true;
 }

--- a/src/taskClassifier.ts
+++ b/src/taskClassifier.ts
@@ -1,0 +1,10 @@
+export type TaskClass = 'build' | 'test' | 'none';
+
+const TEST_NAME_PATTERN = /(^|[^a-z0-9])(test|tests|pester|spec|specs)([^a-z0-9]|$)/i;
+const BUILD_NAME_PATTERN = /(^|[^a-z0-9])(build|compile|publish|package|pack|release|dist)([^a-z0-9]|$)/i;
+
+export function classifyByName(name: string): TaskClass {
+    if (TEST_NAME_PATTERN.test(name)) { return 'test'; }
+    if (BUILD_NAME_PATTERN.test(name)) { return 'build'; }
+    return 'none';
+}

--- a/src/taskProvider.ts
+++ b/src/taskProvider.ts
@@ -5,6 +5,7 @@ import { TASK_TYPE } from './constants.js';
 import { logError } from './log.js';
 import { detectPowerShellExecutable } from './powershellUtils.js';
 import { PsakeModuleResolver, resolveAllTasks } from './moduleResolver.js';
+import { classifyByName } from './taskClassifier.js';
 
 export interface PsakeTaskDefinition extends vscode.TaskDefinition {
     type: 'psake';
@@ -238,6 +239,7 @@ export class PsakeTaskProvider implements vscode.TaskProvider {
         const extraShellArgs: string[] = config.get('shellArgs') ?? ['-NoProfile'];
 
         const problemMatcherEnabled: boolean = config.get('problemMatcher.enabled') ?? true;
+        const classifyEnabled: boolean = config.get('classifyByName') ?? true;
 
         const shellOptions: vscode.ShellExecutionOptions = {
             executable,
@@ -249,18 +251,27 @@ export class PsakeTaskProvider implements vscode.TaskProvider {
             shellOptions.env = { PSAKE_OUTPUT_FORMAT: 'Annotated' };
         }
 
+        const cls = classifyEnabled ? classifyByName(def.task) : 'none';
+        const matchers = problemMatcherEnabled
+            ? (cls === 'test'
+                ? ['$psake', '$psake-powershell', '$pester']
+                : ['$psake', '$psake-powershell'])
+            : [];
+
         const task = new vscode.Task(
             def,
             folder,
             def.task,
             'psake',
             new vscode.ShellExecution(command, shellOptions),
-            problemMatcherEnabled ? ['$psake', '$psake-powershell'] : []
+            matchers
         );
 
         task.detail = description || `Run psake task '${def.task}'`;
 
-        if (def.task.toLowerCase() === 'default') {
+        if (cls === 'test') {
+            task.group = vscode.TaskGroup.Test;
+        } else if (cls === 'build' || def.task.toLowerCase() === 'default') {
             task.group = vscode.TaskGroup.Build;
         }
 


### PR DESCRIPTION
## [1.5.0] - 2026-04-12

### Added

- **Build/Test classification for psake tasks**: auto-detected tasks whose names match patterns like `test`/`pester`/`spec` are placed in the Test group and get the `$pester` problem matcher appended; names matching `build`/`compile`/`publish`/`package`/`release`/`dist` are placed in the Build group. This makes "Run Test Task" and "Run Build Task" work without any configuration.
- The "Sync Tasks" command uses the same classifier to pre-select tasks and prompts for confirmation before writing `tasks.json`, so persisted entries reflect user intent rather than pure heuristic.
- New setting `psake.classifyByName` (default: `true`) controls both behaviors. Disable to skip classification entirely.

### Changed

- Gallery banner color updated to `#1c1e21` for better contrast on the Marketplace listing.

## Test plan

- [ ] Install the VSIX in a workspace with a psakefile containing tasks named `Test`, `Build`, and something uncategorized; verify "Run Test Task" / "Run Build Task" pick up the right ones.
- [ ] Run "psake: Sync Tasks to tasks.json"; verify the two-step Test/Build quick-pick appears with the heuristic pre-selections and that the written entries include `group` and (for test tasks) `$pester`.
- [ ] Set `psake.classifyByName` to `false` and confirm the provider emits ungrouped tasks and sync skips the prompts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)